### PR TITLE
Fix for "env: node: No such file or directory" in macOS 

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -52,6 +52,29 @@ fn main() {
     // Initialize logger
     env_logger::init();
 
+    // Fix PATH for macOS app bundles to include common Node.js locations
+    if cfg!(target_os = "macos") {
+        let current_path = std::env::var("PATH").unwrap_or_default();
+        let common_paths = vec![
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+        ];
+        
+        let mut new_path_parts = vec![];
+        for path in &common_paths {
+            if std::path::Path::new(path).exists() && !current_path.contains(path) {
+                new_path_parts.push(path.to_string());
+            }
+        }
+        
+        if !new_path_parts.is_empty() {
+            new_path_parts.push(current_path);
+            let enhanced_path = new_path_parts.join(":");
+            std::env::set_var("PATH", enhanced_path);
+            log::info!("Enhanced PATH for macOS app bundle");
+        }
+    }
+
     // Check if we need to activate sandbox in this process
     if sandbox::executor::should_activate_sandbox() {
         // This is a child process that needs sandbox activation

--- a/src/components/ClaudeCodeSession.tsx
+++ b/src/components/ClaudeCodeSession.tsx
@@ -381,11 +381,11 @@ export const ClaudeCodeSession: React.FC<ClaudeCodeSessionProps> = ({
       // Execute the appropriate command
       if (effectiveSession && !isFirstPrompt) {
         console.log('[ClaudeCodeSession] Resuming session:', effectiveSession.id);
-        await api.resumeClaudeCode(projectPath, effectiveSession.id, prompt, model);
+        await api.resumeClaudeCode(projectPath, effectiveSession.id, prompt, model, claudeSessionId || undefined);
       } else {
         console.log('[ClaudeCodeSession] Starting new session');
         setIsFirstPrompt(false);
-        await api.executeClaudeCode(projectPath, prompt, model);
+        await api.executeClaudeCode(projectPath, prompt, model, claudeSessionId || undefined);
       }
     } catch (err) {
       console.error("Failed to send prompt:", err);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1019,22 +1019,22 @@ export const api = {
   /**
    * Executes a new interactive Claude Code session with streaming output
    */
-  async executeClaudeCode(projectPath: string, prompt: string, model: string): Promise<void> {
-    return invoke("execute_claude_code", { projectPath, prompt, model });
+  async executeClaudeCode(projectPath: string, prompt: string, model: string, sessionId?: string): Promise<void> {
+    return invoke("execute_claude_code", { projectPath, prompt, model, sessionId });
   },
 
   /**
    * Continues an existing Claude Code conversation with streaming output
    */
-  async continueClaudeCode(projectPath: string, prompt: string, model: string): Promise<void> {
-    return invoke("continue_claude_code", { projectPath, prompt, model });
+  async continueClaudeCode(projectPath: string, prompt: string, model: string, sessionId?: string): Promise<void> {
+    return invoke("continue_claude_code", { projectPath, prompt, model, sessionId });
   },
 
   /**
    * Resumes an existing Claude Code session by ID with streaming output
    */
-  async resumeClaudeCode(projectPath: string, sessionId: string, prompt: string, model: string): Promise<void> {
-    return invoke("resume_claude_code", { projectPath, sessionId, prompt, model });
+  async resumeClaudeCode(projectPath: string, sessionId: string, prompt: string, model: string, frontendSessionId?: string): Promise<void> {
+    return invoke("resume_claude_code", { projectPath, sessionId, prompt, model, frontendSessionId });
   },
 
   /**


### PR DESCRIPTION
# Fix for "env: node: No such file or directory" in macOS 

## Problem

When building on macOS you may encounter the error:

```
env: node: No such file or directory
```

This happens because macOS app bundles have a very restricted `PATH` environment variable that doesn't include common locations where Node.js is installed (like `/opt/homebrew/bin` for Homebrew on Apple Silicon Macs).

## Root Cause

- macOS app bundles run with a minimal `PATH` (typically just `/usr/bin:/bin:/usr/sbin:/sbin`)
- Node.js installed via Homebrew goes to `/opt/homebrew/bin` (Apple Silicon) or `/usr/local/bin` (Intel)
- Scripts with shebangs like `#!/usr/bin/env node` fail because `env` can't find `node` in the restricted PATH

## Solution

Add PATH enhancement at the beginning of the app's `main()` function in `src-tauri/src/main.rs`: