### PR TITLE
fix: make chat reply input non-floating with fixed bottom layout

### DIFF
--- a/src/components/ClaudeCodeSession.tsx
+++ b/src/components/ClaudeCodeSession.tsx
@@ -647,7 +647,7 @@ export const ClaudeCodeSession: React.FC<ClaudeCodeSessionProps> = ({
       </div>
 
       {/* Loading and Error indicators positioned relative to the scroll container */}
-      <div className="sticky bottom-0 w-full flex flex-col items-center pb-40">
+      <div className="sticky bottom-0 w-full flex flex-col items-center pb-4">
         {isLoading && (
           <motion.div
             initial={{ opacity: 0 }}

--- a/src/components/FloatingPromptInput.tsx
+++ b/src/components/FloatingPromptInput.tsx
@@ -619,10 +619,10 @@ const FloatingPromptInputInner = (
         )}
       </AnimatePresence>
 
-      {/* Fixed Position Input Bar */}
+      {/* Bottom Input Bar (non-floating) */}
       <div
         className={cn(
-          "fixed bottom-0 left-0 right-0 z-40 bg-background border-t border-border",
+          "bg-background border-t border-border",
           dragActive && "ring-2 ring-primary ring-offset-2",
           className
         )}


### PR DESCRIPTION
## Summary

This PR changes the FloatingPromptInput from a floating overlay to a fixed bottom component that's part of the normal document flow.

## Problem

The floating input with `fixed` positioning and z-40 can overlap with chat messages, making them unreadable when scrolling to the bottom of a conversation. This creates a poor user experience where users cannot see the latest messages in the chat.

## Solution

- Removed `fixed bottom-0 left-0 right-0 z-40` positioning from FloatingPromptInput component
- Changed from floating overlay to standard layout flow  
- Reduced message list bottom padding from `pb-40` to `pb-4`
- Input now stays at the bottom without overlaying content

## Changes Made

- `src/components/FloatingPromptInput.tsx`: Removed fixed positioning classes
- `src/components/ClaudeCodeSession.tsx`: Reduced bottom padding

## Testing

- ✅ Built and tested on macOS
- ✅ Verified input no longer overlaps messages
- ✅ Scrolling behavior works correctly
- ✅ All existing functionality preserved

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update