### PR TITLE
feat(nix): add complete Nix build system with Tauri and OpenGL fixes

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+use flake
+
+dotenv_if_exists .env

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ dist-ssr
 temp_lib/
 
 .cursor/
+.direnv/

--- a/bun.nix
+++ b/bun.nix
@@ -1,0 +1,3319 @@
+# Set of Bun packages to install
+{
+  "@ampproject/remapping" = {
+    out_path = "@ampproject/remapping";
+    name = "@ampproject/remapping@2.3.0";
+    url = "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz";
+    hash = "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==";
+  };
+  "@babel/code-frame" = {
+    out_path = "@babel/code-frame";
+    name = "@babel/code-frame@7.27.1";
+    url = "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz";
+    hash = "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==";
+  };
+  "@babel/compat-data" = {
+    out_path = "@babel/compat-data";
+    name = "@babel/compat-data@7.27.5";
+    url = "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.5.tgz";
+    hash = "sha512-KiRAp/VoJaWkkte84TvUd9qjdbZAdiqyvMxrGl1N6vzFogKmaLgoM3L1kgtLicp2HP5fBJS8JrZKLVIZGVJAVg==";
+  };
+  "@babel/core" = {
+    out_path = "@babel/core";
+    name = "@babel/core@7.27.4";
+    url = "https://registry.npmjs.org/@babel/core/-/core-7.27.4.tgz";
+    hash = "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==";
+  };
+  "@babel/core/semver" = {
+    out_path = "@babel/core/node_modules/semver";
+    binaries = {
+      "semver" = "../@babel/core/node_modules/semver/bin/semver.js";
+    };
+    name = "semver@6.3.1";
+    url = "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz";
+    hash = "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==";
+  };
+  "@babel/generator" = {
+    out_path = "@babel/generator";
+    name = "@babel/generator@7.27.5";
+    url = "https://registry.npmjs.org/@babel/generator/-/generator-7.27.5.tgz";
+    hash = "sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==";
+  };
+  "@babel/helper-compilation-targets" = {
+    out_path = "@babel/helper-compilation-targets";
+    name = "@babel/helper-compilation-targets@7.27.2";
+    url = "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz";
+    hash = "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==";
+  };
+  "@babel/helper-compilation-targets/semver" = {
+    out_path = "@babel/helper-compilation-targets/node_modules/semver";
+    binaries = {
+      "semver" = "../@babel/helper-compilation-targets/node_modules/semver/bin/semver.js";
+    };
+    name = "semver@6.3.1";
+    url = "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz";
+    hash = "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==";
+  };
+  "@babel/helper-module-imports" = {
+    out_path = "@babel/helper-module-imports";
+    name = "@babel/helper-module-imports@7.27.1";
+    url = "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz";
+    hash = "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==";
+  };
+  "@babel/helper-module-transforms" = {
+    out_path = "@babel/helper-module-transforms";
+    name = "@babel/helper-module-transforms@7.27.3";
+    url = "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz";
+    hash = "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==";
+  };
+  "@babel/helper-plugin-utils" = {
+    out_path = "@babel/helper-plugin-utils";
+    name = "@babel/helper-plugin-utils@7.27.1";
+    url = "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz";
+    hash = "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==";
+  };
+  "@babel/helper-string-parser" = {
+    out_path = "@babel/helper-string-parser";
+    name = "@babel/helper-string-parser@7.27.1";
+    url = "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz";
+    hash = "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==";
+  };
+  "@babel/helper-validator-identifier" = {
+    out_path = "@babel/helper-validator-identifier";
+    name = "@babel/helper-validator-identifier@7.27.1";
+    url = "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz";
+    hash = "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==";
+  };
+  "@babel/helper-validator-option" = {
+    out_path = "@babel/helper-validator-option";
+    name = "@babel/helper-validator-option@7.27.1";
+    url = "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz";
+    hash = "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==";
+  };
+  "@babel/helpers" = {
+    out_path = "@babel/helpers";
+    name = "@babel/helpers@7.27.6";
+    url = "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz";
+    hash = "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==";
+  };
+  "@babel/parser" = {
+    out_path = "@babel/parser";
+    binaries = {
+      "parser" = "../@babel/parser/./bin/babel-parser.js";
+    };
+    name = "@babel/parser@7.27.5";
+    url = "https://registry.npmjs.org/@babel/parser/-/parser-7.27.5.tgz";
+    hash = "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==";
+  };
+  "@babel/plugin-transform-react-jsx-self" = {
+    out_path = "@babel/plugin-transform-react-jsx-self";
+    name = "@babel/plugin-transform-react-jsx-self@7.27.1";
+    url = "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz";
+    hash = "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==";
+  };
+  "@babel/plugin-transform-react-jsx-source" = {
+    out_path = "@babel/plugin-transform-react-jsx-source";
+    name = "@babel/plugin-transform-react-jsx-source@7.27.1";
+    url = "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz";
+    hash = "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==";
+  };
+  "@babel/runtime" = {
+    out_path = "@babel/runtime";
+    name = "@babel/runtime@7.27.6";
+    url = "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz";
+    hash = "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==";
+  };
+  "@babel/template" = {
+    out_path = "@babel/template";
+    name = "@babel/template@7.27.2";
+    url = "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz";
+    hash = "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==";
+  };
+  "@babel/traverse" = {
+    out_path = "@babel/traverse";
+    name = "@babel/traverse@7.27.4";
+    url = "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.4.tgz";
+    hash = "sha512-oNcu2QbHqts9BtOWJosOVJapWjBDSxGCpFvikNR5TGDYDQf3JwpIoMzIKrvfoti93cLfPJEG4tH9SPVeyCGgdA==";
+  };
+  "@babel/types" = {
+    out_path = "@babel/types";
+    name = "@babel/types@7.27.6";
+    url = "https://registry.npmjs.org/@babel/types/-/types-7.27.6.tgz";
+    hash = "sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==";
+  };
+  "@emnapi/runtime" = {
+    out_path = "@emnapi/runtime";
+    name = "@emnapi/runtime@1.4.3";
+    url = "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.3.tgz";
+    hash = "sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==";
+  };
+  "@esbuild/aix-ppc64" = {
+    out_path = "@esbuild/aix-ppc64";
+    name = "@esbuild/aix-ppc64@0.25.5";
+    url = "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.5.tgz";
+    hash = "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==";
+  };
+  "@esbuild/android-arm" = {
+    out_path = "@esbuild/android-arm";
+    name = "@esbuild/android-arm@0.25.5";
+    url = "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.5.tgz";
+    hash = "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==";
+  };
+  "@esbuild/android-arm64" = {
+    out_path = "@esbuild/android-arm64";
+    name = "@esbuild/android-arm64@0.25.5";
+    url = "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.5.tgz";
+    hash = "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==";
+  };
+  "@esbuild/android-x64" = {
+    out_path = "@esbuild/android-x64";
+    name = "@esbuild/android-x64@0.25.5";
+    url = "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.5.tgz";
+    hash = "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==";
+  };
+  "@esbuild/darwin-arm64" = {
+    out_path = "@esbuild/darwin-arm64";
+    name = "@esbuild/darwin-arm64@0.25.5";
+    url = "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz";
+    hash = "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==";
+  };
+  "@esbuild/darwin-x64" = {
+    out_path = "@esbuild/darwin-x64";
+    name = "@esbuild/darwin-x64@0.25.5";
+    url = "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.5.tgz";
+    hash = "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==";
+  };
+  "@esbuild/freebsd-arm64" = {
+    out_path = "@esbuild/freebsd-arm64";
+    name = "@esbuild/freebsd-arm64@0.25.5";
+    url = "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.5.tgz";
+    hash = "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==";
+  };
+  "@esbuild/freebsd-x64" = {
+    out_path = "@esbuild/freebsd-x64";
+    name = "@esbuild/freebsd-x64@0.25.5";
+    url = "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.5.tgz";
+    hash = "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==";
+  };
+  "@esbuild/linux-arm" = {
+    out_path = "@esbuild/linux-arm";
+    name = "@esbuild/linux-arm@0.25.5";
+    url = "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.5.tgz";
+    hash = "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==";
+  };
+  "@esbuild/linux-arm64" = {
+    out_path = "@esbuild/linux-arm64";
+    name = "@esbuild/linux-arm64@0.25.5";
+    url = "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.5.tgz";
+    hash = "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==";
+  };
+  "@esbuild/linux-ia32" = {
+    out_path = "@esbuild/linux-ia32";
+    name = "@esbuild/linux-ia32@0.25.5";
+    url = "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.5.tgz";
+    hash = "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==";
+  };
+  "@esbuild/linux-loong64" = {
+    out_path = "@esbuild/linux-loong64";
+    name = "@esbuild/linux-loong64@0.25.5";
+    url = "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.5.tgz";
+    hash = "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==";
+  };
+  "@esbuild/linux-mips64el" = {
+    out_path = "@esbuild/linux-mips64el";
+    name = "@esbuild/linux-mips64el@0.25.5";
+    url = "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.5.tgz";
+    hash = "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==";
+  };
+  "@esbuild/linux-ppc64" = {
+    out_path = "@esbuild/linux-ppc64";
+    name = "@esbuild/linux-ppc64@0.25.5";
+    url = "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.5.tgz";
+    hash = "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==";
+  };
+  "@esbuild/linux-riscv64" = {
+    out_path = "@esbuild/linux-riscv64";
+    name = "@esbuild/linux-riscv64@0.25.5";
+    url = "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.5.tgz";
+    hash = "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==";
+  };
+  "@esbuild/linux-s390x" = {
+    out_path = "@esbuild/linux-s390x";
+    name = "@esbuild/linux-s390x@0.25.5";
+    url = "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.5.tgz";
+    hash = "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==";
+  };
+  "@esbuild/linux-x64" = {
+    out_path = "@esbuild/linux-x64";
+    name = "@esbuild/linux-x64@0.25.5";
+    url = "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.5.tgz";
+    hash = "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==";
+  };
+  "@esbuild/netbsd-arm64" = {
+    out_path = "@esbuild/netbsd-arm64";
+    name = "@esbuild/netbsd-arm64@0.25.5";
+    url = "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.5.tgz";
+    hash = "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==";
+  };
+  "@esbuild/netbsd-x64" = {
+    out_path = "@esbuild/netbsd-x64";
+    name = "@esbuild/netbsd-x64@0.25.5";
+    url = "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.5.tgz";
+    hash = "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==";
+  };
+  "@esbuild/openbsd-arm64" = {
+    out_path = "@esbuild/openbsd-arm64";
+    name = "@esbuild/openbsd-arm64@0.25.5";
+    url = "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.5.tgz";
+    hash = "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==";
+  };
+  "@esbuild/openbsd-x64" = {
+    out_path = "@esbuild/openbsd-x64";
+    name = "@esbuild/openbsd-x64@0.25.5";
+    url = "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.5.tgz";
+    hash = "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==";
+  };
+  "@esbuild/sunos-x64" = {
+    out_path = "@esbuild/sunos-x64";
+    name = "@esbuild/sunos-x64@0.25.5";
+    url = "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.5.tgz";
+    hash = "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==";
+  };
+  "@esbuild/win32-arm64" = {
+    out_path = "@esbuild/win32-arm64";
+    name = "@esbuild/win32-arm64@0.25.5";
+    url = "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.5.tgz";
+    hash = "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==";
+  };
+  "@esbuild/win32-ia32" = {
+    out_path = "@esbuild/win32-ia32";
+    name = "@esbuild/win32-ia32@0.25.5";
+    url = "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.5.tgz";
+    hash = "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==";
+  };
+  "@esbuild/win32-x64" = {
+    out_path = "@esbuild/win32-x64";
+    name = "@esbuild/win32-x64@0.25.5";
+    url = "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.5.tgz";
+    hash = "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==";
+  };
+  "@floating-ui/core" = {
+    out_path = "@floating-ui/core";
+    name = "@floating-ui/core@1.7.1";
+    url = "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.1.tgz";
+    hash = "sha512-azI0DrjMMfIug/ExbBaeDVJXcY0a7EPvPjb2xAJPa4HeimBX+Z18HK8QQR3jb6356SnDDdxx+hinMLcJEDdOjw==";
+  };
+  "@floating-ui/dom" = {
+    out_path = "@floating-ui/dom";
+    name = "@floating-ui/dom@1.7.1";
+    url = "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.1.tgz";
+    hash = "sha512-cwsmW/zyw5ltYTUeeYJ60CnQuPqmGwuGVhG9w0PRaRKkAyi38BT5CKrpIbb+jtahSwUl04cWzSx9ZOIxeS6RsQ==";
+  };
+  "@floating-ui/react-dom" = {
+    out_path = "@floating-ui/react-dom";
+    name = "@floating-ui/react-dom@2.1.3";
+    url = "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.3.tgz";
+    hash = "sha512-huMBfiU9UnQ2oBwIhgzyIiSpVgvlDstU8CX0AF+wS+KzmYMs0J2a3GwuFHV1Lz+jlrQGeC1fF+Nv0QoumyV0bA==";
+  };
+  "@floating-ui/utils" = {
+    out_path = "@floating-ui/utils";
+    name = "@floating-ui/utils@0.2.9";
+    url = "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz";
+    hash = "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==";
+  };
+  "@hookform/resolvers" = {
+    out_path = "@hookform/resolvers";
+    name = "@hookform/resolvers@3.10.0";
+    url = "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz";
+    hash = "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==";
+  };
+  "@img/sharp-darwin-arm64" = {
+    out_path = "@img/sharp-darwin-arm64";
+    name = "@img/sharp-darwin-arm64@0.34.2";
+    url = "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.2.tgz";
+    hash = "sha512-OfXHZPppddivUJnqyKoi5YVeHRkkNE2zUFT2gbpKxp/JZCFYEYubnMg+gOp6lWfasPrTS+KPosKqdI+ELYVDtg==";
+  };
+  "@img/sharp-darwin-x64" = {
+    out_path = "@img/sharp-darwin-x64";
+    name = "@img/sharp-darwin-x64@0.34.2";
+    url = "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.2.tgz";
+    hash = "sha512-dYvWqmjU9VxqXmjEtjmvHnGqF8GrVjM2Epj9rJ6BUIXvk8slvNDJbhGFvIoXzkDhrJC2jUxNLz/GUjjvSzfw+g==";
+  };
+  "@img/sharp-libvips-darwin-arm64" = {
+    out_path = "@img/sharp-libvips-darwin-arm64";
+    name = "@img/sharp-libvips-darwin-arm64@1.1.0";
+    url = "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.1.0.tgz";
+    hash = "sha512-HZ/JUmPwrJSoM4DIQPv/BfNh9yrOA8tlBbqbLz4JZ5uew2+o22Ik+tHQJcih7QJuSa0zo5coHTfD5J8inqj9DA==";
+  };
+  "@img/sharp-libvips-darwin-x64" = {
+    out_path = "@img/sharp-libvips-darwin-x64";
+    name = "@img/sharp-libvips-darwin-x64@1.1.0";
+    url = "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.1.0.tgz";
+    hash = "sha512-Xzc2ToEmHN+hfvsl9wja0RlnXEgpKNmftriQp6XzY/RaSfwD9th+MSh0WQKzUreLKKINb3afirxW7A0fz2YWuQ==";
+  };
+  "@img/sharp-libvips-linux-arm" = {
+    out_path = "@img/sharp-libvips-linux-arm";
+    name = "@img/sharp-libvips-linux-arm@1.1.0";
+    url = "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.1.0.tgz";
+    hash = "sha512-s8BAd0lwUIvYCJyRdFqvsj+BJIpDBSxs6ivrOPm/R7piTs5UIwY5OjXrP2bqXC9/moGsyRa37eYWYCOGVXxVrA==";
+  };
+  "@img/sharp-libvips-linux-arm64" = {
+    out_path = "@img/sharp-libvips-linux-arm64";
+    name = "@img/sharp-libvips-linux-arm64@1.1.0";
+    url = "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.1.0.tgz";
+    hash = "sha512-IVfGJa7gjChDET1dK9SekxFFdflarnUB8PwW8aGwEoF3oAsSDuNUTYS+SKDOyOJxQyDC1aPFMuRYLoDInyV9Ew==";
+  };
+  "@img/sharp-libvips-linux-ppc64" = {
+    out_path = "@img/sharp-libvips-linux-ppc64";
+    name = "@img/sharp-libvips-linux-ppc64@1.1.0";
+    url = "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.1.0.tgz";
+    hash = "sha512-tiXxFZFbhnkWE2LA8oQj7KYR+bWBkiV2nilRldT7bqoEZ4HiDOcePr9wVDAZPi/Id5fT1oY9iGnDq20cwUz8lQ==";
+  };
+  "@img/sharp-libvips-linux-s390x" = {
+    out_path = "@img/sharp-libvips-linux-s390x";
+    name = "@img/sharp-libvips-linux-s390x@1.1.0";
+    url = "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.1.0.tgz";
+    hash = "sha512-xukSwvhguw7COyzvmjydRb3x/09+21HykyapcZchiCUkTThEQEOMtBj9UhkaBRLuBrgLFzQ2wbxdeCCJW/jgJA==";
+  };
+  "@img/sharp-libvips-linux-x64" = {
+    out_path = "@img/sharp-libvips-linux-x64";
+    name = "@img/sharp-libvips-linux-x64@1.1.0";
+    url = "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.1.0.tgz";
+    hash = "sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q==";
+  };
+  "@img/sharp-libvips-linuxmusl-arm64" = {
+    out_path = "@img/sharp-libvips-linuxmusl-arm64";
+    name = "@img/sharp-libvips-linuxmusl-arm64@1.1.0";
+    url = "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.1.0.tgz";
+    hash = "sha512-jYZdG+whg0MDK+q2COKbYidaqW/WTz0cc1E+tMAusiDygrM4ypmSCjOJPmFTvHHJ8j/6cAGyeDWZOsK06tP33w==";
+  };
+  "@img/sharp-libvips-linuxmusl-x64" = {
+    out_path = "@img/sharp-libvips-linuxmusl-x64";
+    name = "@img/sharp-libvips-linuxmusl-x64@1.1.0";
+    url = "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.1.0.tgz";
+    hash = "sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A==";
+  };
+  "@img/sharp-linux-arm" = {
+    out_path = "@img/sharp-linux-arm";
+    name = "@img/sharp-linux-arm@0.34.2";
+    url = "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.2.tgz";
+    hash = "sha512-0DZzkvuEOqQUP9mo2kjjKNok5AmnOr1jB2XYjkaoNRwpAYMDzRmAqUIa1nRi58S2WswqSfPOWLNOr0FDT3H5RQ==";
+  };
+  "@img/sharp-linux-arm64" = {
+    out_path = "@img/sharp-linux-arm64";
+    name = "@img/sharp-linux-arm64@0.34.2";
+    url = "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.2.tgz";
+    hash = "sha512-D8n8wgWmPDakc83LORcfJepdOSN6MvWNzzz2ux0MnIbOqdieRZwVYY32zxVx+IFUT8er5KPcyU3XXsn+GzG/0Q==";
+  };
+  "@img/sharp-linux-s390x" = {
+    out_path = "@img/sharp-linux-s390x";
+    name = "@img/sharp-linux-s390x@0.34.2";
+    url = "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.2.tgz";
+    hash = "sha512-EGZ1xwhBI7dNISwxjChqBGELCWMGDvmxZXKjQRuqMrakhO8QoMgqCrdjnAqJq/CScxfRn+Bb7suXBElKQpPDiw==";
+  };
+  "@img/sharp-linux-x64" = {
+    out_path = "@img/sharp-linux-x64";
+    name = "@img/sharp-linux-x64@0.34.2";
+    url = "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.2.tgz";
+    hash = "sha512-sD7J+h5nFLMMmOXYH4DD9UtSNBD05tWSSdWAcEyzqW8Cn5UxXvsHAxmxSesYUsTOBmUnjtxghKDl15EvfqLFbQ==";
+  };
+  "@img/sharp-linuxmusl-arm64" = {
+    out_path = "@img/sharp-linuxmusl-arm64";
+    name = "@img/sharp-linuxmusl-arm64@0.34.2";
+    url = "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.2.tgz";
+    hash = "sha512-NEE2vQ6wcxYav1/A22OOxoSOGiKnNmDzCYFOZ949xFmrWZOVII1Bp3NqVVpvj+3UeHMFyN5eP/V5hzViQ5CZNA==";
+  };
+  "@img/sharp-linuxmusl-x64" = {
+    out_path = "@img/sharp-linuxmusl-x64";
+    name = "@img/sharp-linuxmusl-x64@0.34.2";
+    url = "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.2.tgz";
+    hash = "sha512-DOYMrDm5E6/8bm/yQLCWyuDJwUnlevR8xtF8bs+gjZ7cyUNYXiSf/E8Kp0Ss5xasIaXSHzb888V1BE4i1hFhAA==";
+  };
+  "@img/sharp-wasm32" = {
+    out_path = "@img/sharp-wasm32";
+    name = "@img/sharp-wasm32@0.34.2";
+    url = "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.2.tgz";
+    hash = "sha512-/VI4mdlJ9zkaq53MbIG6rZY+QRN3MLbR6usYlgITEzi4Rpx5S6LFKsycOQjkOGmqTNmkIdLjEvooFKwww6OpdQ==";
+  };
+  "@img/sharp-win32-arm64" = {
+    out_path = "@img/sharp-win32-arm64";
+    name = "@img/sharp-win32-arm64@0.34.2";
+    url = "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.2.tgz";
+    hash = "sha512-cfP/r9FdS63VA5k0xiqaNaEoGxBg9k7uE+RQGzuK9fHt7jib4zAVVseR9LsE4gJcNWgT6APKMNnCcnyOtmSEUQ==";
+  };
+  "@img/sharp-win32-ia32" = {
+    out_path = "@img/sharp-win32-ia32";
+    name = "@img/sharp-win32-ia32@0.34.2";
+    url = "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.2.tgz";
+    hash = "sha512-QLjGGvAbj0X/FXl8n1WbtQ6iVBpWU7JO94u/P2M4a8CFYsvQi4GW2mRy/JqkRx0qpBzaOdKJKw8uc930EX2AHw==";
+  };
+  "@img/sharp-win32-x64" = {
+    out_path = "@img/sharp-win32-x64";
+    name = "@img/sharp-win32-x64@0.34.2";
+    url = "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.2.tgz";
+    hash = "sha512-aUdT6zEYtDKCaxkofmmJDJYGCf0+pJg3eU9/oBuqvEeoB9dKI6ZLc/1iLJCTuJQDO4ptntAlkUmHgGjyuobZbw==";
+  };
+  "@isaacs/fs-minipass" = {
+    out_path = "@isaacs/fs-minipass";
+    name = "@isaacs/fs-minipass@4.0.1";
+    url = "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz";
+    hash = "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==";
+  };
+  "@jridgewell/gen-mapping" = {
+    out_path = "@jridgewell/gen-mapping";
+    name = "@jridgewell/gen-mapping@0.3.8";
+    url = "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz";
+    hash = "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==";
+  };
+  "@jridgewell/resolve-uri" = {
+    out_path = "@jridgewell/resolve-uri";
+    name = "@jridgewell/resolve-uri@3.1.2";
+    url = "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz";
+    hash = "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==";
+  };
+  "@jridgewell/set-array" = {
+    out_path = "@jridgewell/set-array";
+    name = "@jridgewell/set-array@1.2.1";
+    url = "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz";
+    hash = "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==";
+  };
+  "@jridgewell/sourcemap-codec" = {
+    out_path = "@jridgewell/sourcemap-codec";
+    name = "@jridgewell/sourcemap-codec@1.5.0";
+    url = "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz";
+    hash = "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==";
+  };
+  "@jridgewell/trace-mapping" = {
+    out_path = "@jridgewell/trace-mapping";
+    name = "@jridgewell/trace-mapping@0.3.25";
+    url = "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz";
+    hash = "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==";
+  };
+  "@parcel/watcher" = {
+    out_path = "@parcel/watcher";
+    name = "@parcel/watcher@2.5.1";
+    url = "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz";
+    hash = "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==";
+  };
+  "@parcel/watcher-android-arm64" = {
+    out_path = "@parcel/watcher-android-arm64";
+    name = "@parcel/watcher-android-arm64@2.5.1";
+    url = "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz";
+    hash = "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==";
+  };
+  "@parcel/watcher-darwin-arm64" = {
+    out_path = "@parcel/watcher-darwin-arm64";
+    name = "@parcel/watcher-darwin-arm64@2.5.1";
+    url = "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz";
+    hash = "sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==";
+  };
+  "@parcel/watcher-darwin-x64" = {
+    out_path = "@parcel/watcher-darwin-x64";
+    name = "@parcel/watcher-darwin-x64@2.5.1";
+    url = "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz";
+    hash = "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==";
+  };
+  "@parcel/watcher-freebsd-x64" = {
+    out_path = "@parcel/watcher-freebsd-x64";
+    name = "@parcel/watcher-freebsd-x64@2.5.1";
+    url = "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz";
+    hash = "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==";
+  };
+  "@parcel/watcher-linux-arm-glibc" = {
+    out_path = "@parcel/watcher-linux-arm-glibc";
+    name = "@parcel/watcher-linux-arm-glibc@2.5.1";
+    url = "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz";
+    hash = "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==";
+  };
+  "@parcel/watcher-linux-arm-musl" = {
+    out_path = "@parcel/watcher-linux-arm-musl";
+    name = "@parcel/watcher-linux-arm-musl@2.5.1";
+    url = "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz";
+    hash = "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==";
+  };
+  "@parcel/watcher-linux-arm64-glibc" = {
+    out_path = "@parcel/watcher-linux-arm64-glibc";
+    name = "@parcel/watcher-linux-arm64-glibc@2.5.1";
+    url = "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz";
+    hash = "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==";
+  };
+  "@parcel/watcher-linux-arm64-musl" = {
+    out_path = "@parcel/watcher-linux-arm64-musl";
+    name = "@parcel/watcher-linux-arm64-musl@2.5.1";
+    url = "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz";
+    hash = "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==";
+  };
+  "@parcel/watcher-linux-x64-glibc" = {
+    out_path = "@parcel/watcher-linux-x64-glibc";
+    name = "@parcel/watcher-linux-x64-glibc@2.5.1";
+    url = "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz";
+    hash = "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==";
+  };
+  "@parcel/watcher-linux-x64-musl" = {
+    out_path = "@parcel/watcher-linux-x64-musl";
+    name = "@parcel/watcher-linux-x64-musl@2.5.1";
+    url = "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz";
+    hash = "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==";
+  };
+  "@parcel/watcher-win32-arm64" = {
+    out_path = "@parcel/watcher-win32-arm64";
+    name = "@parcel/watcher-win32-arm64@2.5.1";
+    url = "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz";
+    hash = "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==";
+  };
+  "@parcel/watcher-win32-ia32" = {
+    out_path = "@parcel/watcher-win32-ia32";
+    name = "@parcel/watcher-win32-ia32@2.5.1";
+    url = "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz";
+    hash = "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==";
+  };
+  "@parcel/watcher-win32-x64" = {
+    out_path = "@parcel/watcher-win32-x64";
+    name = "@parcel/watcher-win32-x64@2.5.1";
+    url = "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz";
+    hash = "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==";
+  };
+  "@parcel/watcher/detect-libc" = {
+    out_path = "@parcel/watcher/node_modules/detect-libc";
+    binaries = {
+      "detect-libc" = "../@parcel/watcher/node_modules/detect-libc/./bin/detect-libc.js";
+    };
+    name = "detect-libc@1.0.3";
+    url = "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz";
+    hash = "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==";
+  };
+  "@radix-ui/number" = {
+    out_path = "@radix-ui/number";
+    name = "@radix-ui/number@1.1.1";
+    url = "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz";
+    hash = "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==";
+  };
+  "@radix-ui/primitive" = {
+    out_path = "@radix-ui/primitive";
+    name = "@radix-ui/primitive@1.1.2";
+    url = "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz";
+    hash = "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==";
+  };
+  "@radix-ui/react-arrow" = {
+    out_path = "@radix-ui/react-arrow";
+    name = "@radix-ui/react-arrow@1.1.7";
+    url = "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz";
+    hash = "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==";
+  };
+  "@radix-ui/react-collection" = {
+    out_path = "@radix-ui/react-collection";
+    name = "@radix-ui/react-collection@1.1.7";
+    url = "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz";
+    hash = "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==";
+  };
+  "@radix-ui/react-compose-refs" = {
+    out_path = "@radix-ui/react-compose-refs";
+    name = "@radix-ui/react-compose-refs@1.1.2";
+    url = "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz";
+    hash = "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==";
+  };
+  "@radix-ui/react-context" = {
+    out_path = "@radix-ui/react-context";
+    name = "@radix-ui/react-context@1.1.2";
+    url = "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz";
+    hash = "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==";
+  };
+  "@radix-ui/react-dialog" = {
+    out_path = "@radix-ui/react-dialog";
+    name = "@radix-ui/react-dialog@1.1.14";
+    url = "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.14.tgz";
+    hash = "sha512-+CpweKjqpzTmwRwcYECQcNYbI8V9VSQt0SNFKeEBLgfucbsLssU6Ppq7wUdNXEGb573bMjFhVjKVll8rmV6zMw==";
+  };
+  "@radix-ui/react-direction" = {
+    out_path = "@radix-ui/react-direction";
+    name = "@radix-ui/react-direction@1.1.1";
+    url = "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz";
+    hash = "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==";
+  };
+  "@radix-ui/react-dismissable-layer" = {
+    out_path = "@radix-ui/react-dismissable-layer";
+    name = "@radix-ui/react-dismissable-layer@1.1.10";
+    url = "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.10.tgz";
+    hash = "sha512-IM1zzRV4W3HtVgftdQiiOmA0AdJlCtMLe00FXaHwgt3rAnNsIyDqshvkIW3hj/iu5hu8ERP7KIYki6NkqDxAwQ==";
+  };
+  "@radix-ui/react-dropdown-menu" = {
+    out_path = "@radix-ui/react-dropdown-menu";
+    name = "@radix-ui/react-dropdown-menu@2.1.15";
+    url = "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.15.tgz";
+    hash = "sha512-mIBnOjgwo9AH3FyKaSWoSu/dYj6VdhJ7frEPiGTeXCdUFHjl9h3mFh2wwhEtINOmYXWhdpf1rY2minFsmaNgVQ==";
+  };
+  "@radix-ui/react-focus-guards" = {
+    out_path = "@radix-ui/react-focus-guards";
+    name = "@radix-ui/react-focus-guards@1.1.2";
+    url = "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.2.tgz";
+    hash = "sha512-fyjAACV62oPV925xFCrH8DR5xWhg9KYtJT4s3u54jxp+L/hbpTY2kIeEFFbFe+a/HCE94zGQMZLIpVTPVZDhaA==";
+  };
+  "@radix-ui/react-focus-scope" = {
+    out_path = "@radix-ui/react-focus-scope";
+    name = "@radix-ui/react-focus-scope@1.1.7";
+    url = "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz";
+    hash = "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==";
+  };
+  "@radix-ui/react-id" = {
+    out_path = "@radix-ui/react-id";
+    name = "@radix-ui/react-id@1.1.1";
+    url = "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz";
+    hash = "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==";
+  };
+  "@radix-ui/react-label" = {
+    out_path = "@radix-ui/react-label";
+    name = "@radix-ui/react-label@2.1.7";
+    url = "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz";
+    hash = "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==";
+  };
+  "@radix-ui/react-menu" = {
+    out_path = "@radix-ui/react-menu";
+    name = "@radix-ui/react-menu@2.1.15";
+    url = "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.15.tgz";
+    hash = "sha512-tVlmA3Vb9n8SZSd+YSbuFR66l87Wiy4du+YE+0hzKQEANA+7cWKH1WgqcEX4pXqxUFQKrWQGHdvEfw00TjFiew==";
+  };
+  "@radix-ui/react-popover" = {
+    out_path = "@radix-ui/react-popover";
+    name = "@radix-ui/react-popover@1.1.14";
+    url = "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.14.tgz";
+    hash = "sha512-ODz16+1iIbGUfFEfKx2HTPKizg2MN39uIOV8MXeHnmdd3i/N9Wt7vU46wbHsqA0xoaQyXVcs0KIlBdOA2Y95bw==";
+  };
+  "@radix-ui/react-popper" = {
+    out_path = "@radix-ui/react-popper";
+    name = "@radix-ui/react-popper@1.2.7";
+    url = "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.7.tgz";
+    hash = "sha512-IUFAccz1JyKcf/RjB552PlWwxjeCJB8/4KxT7EhBHOJM+mN7LdW+B3kacJXILm32xawcMMjb2i0cIZpo+f9kiQ==";
+  };
+  "@radix-ui/react-portal" = {
+    out_path = "@radix-ui/react-portal";
+    name = "@radix-ui/react-portal@1.1.9";
+    url = "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz";
+    hash = "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==";
+  };
+  "@radix-ui/react-presence" = {
+    out_path = "@radix-ui/react-presence";
+    name = "@radix-ui/react-presence@1.1.4";
+    url = "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.4.tgz";
+    hash = "sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA==";
+  };
+  "@radix-ui/react-primitive" = {
+    out_path = "@radix-ui/react-primitive";
+    name = "@radix-ui/react-primitive@2.1.3";
+    url = "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz";
+    hash = "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==";
+  };
+  "@radix-ui/react-radio-group" = {
+    out_path = "@radix-ui/react-radio-group";
+    name = "@radix-ui/react-radio-group@1.3.7";
+    url = "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.7.tgz";
+    hash = "sha512-9w5XhD0KPOrm92OTTE0SysH3sYzHsSTHNvZgUBo/VZ80VdYyB5RneDbc0dKpURS24IxkoFRu/hI0i4XyfFwY6g==";
+  };
+  "@radix-ui/react-roving-focus" = {
+    out_path = "@radix-ui/react-roving-focus";
+    name = "@radix-ui/react-roving-focus@1.1.10";
+    url = "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.10.tgz";
+    hash = "sha512-dT9aOXUen9JSsxnMPv/0VqySQf5eDQ6LCk5Sw28kamz8wSOW2bJdlX2Bg5VUIIcV+6XlHpWTIuTPCf/UNIyq8Q==";
+  };
+  "@radix-ui/react-select" = {
+    out_path = "@radix-ui/react-select";
+    name = "@radix-ui/react-select@2.2.5";
+    url = "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.5.tgz";
+    hash = "sha512-HnMTdXEVuuyzx63ME0ut4+sEMYW6oouHWNGUZc7ddvUWIcfCva/AMoqEW/3wnEllriMWBa0RHspCYnfCWJQYmA==";
+  };
+  "@radix-ui/react-slot" = {
+    out_path = "@radix-ui/react-slot";
+    name = "@radix-ui/react-slot@1.2.3";
+    url = "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz";
+    hash = "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==";
+  };
+  "@radix-ui/react-switch" = {
+    out_path = "@radix-ui/react-switch";
+    name = "@radix-ui/react-switch@1.2.5";
+    url = "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.5.tgz";
+    hash = "sha512-5ijLkak6ZMylXsaImpZ8u4Rlf5grRmoc0p0QeX9VJtlrM4f5m3nCTX8tWga/zOA8PZYIR/t0p2Mnvd7InrJ6yQ==";
+  };
+  "@radix-ui/react-tabs" = {
+    out_path = "@radix-ui/react-tabs";
+    name = "@radix-ui/react-tabs@1.1.12";
+    url = "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.12.tgz";
+    hash = "sha512-GTVAlRVrQrSw3cEARM0nAx73ixrWDPNZAruETn3oHCNP6SbZ/hNxdxp+u7VkIEv3/sFoLq1PfcHrl7Pnp0CDpw==";
+  };
+  "@radix-ui/react-toast" = {
+    out_path = "@radix-ui/react-toast";
+    name = "@radix-ui/react-toast@1.2.14";
+    url = "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.14.tgz";
+    hash = "sha512-nAP5FBxBJGQ/YfUB+r+O6USFVkWq3gAInkxyEnmvEV5jtSbfDhfa4hwX8CraCnbjMLsE7XSf/K75l9xXY7joWg==";
+  };
+  "@radix-ui/react-tooltip" = {
+    out_path = "@radix-ui/react-tooltip";
+    name = "@radix-ui/react-tooltip@1.2.7";
+    url = "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.7.tgz";
+    hash = "sha512-Ap+fNYwKTYJ9pzqW+Xe2HtMRbQ/EeWkj2qykZ6SuEV4iS/o1bZI5ssJbk4D2r8XuDuOBVz/tIx2JObtuqU+5Zw==";
+  };
+  "@radix-ui/react-use-callback-ref" = {
+    out_path = "@radix-ui/react-use-callback-ref";
+    name = "@radix-ui/react-use-callback-ref@1.1.1";
+    url = "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz";
+    hash = "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==";
+  };
+  "@radix-ui/react-use-controllable-state" = {
+    out_path = "@radix-ui/react-use-controllable-state";
+    name = "@radix-ui/react-use-controllable-state@1.2.2";
+    url = "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz";
+    hash = "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==";
+  };
+  "@radix-ui/react-use-effect-event" = {
+    out_path = "@radix-ui/react-use-effect-event";
+    name = "@radix-ui/react-use-effect-event@0.0.2";
+    url = "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz";
+    hash = "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==";
+  };
+  "@radix-ui/react-use-escape-keydown" = {
+    out_path = "@radix-ui/react-use-escape-keydown";
+    name = "@radix-ui/react-use-escape-keydown@1.1.1";
+    url = "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz";
+    hash = "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==";
+  };
+  "@radix-ui/react-use-layout-effect" = {
+    out_path = "@radix-ui/react-use-layout-effect";
+    name = "@radix-ui/react-use-layout-effect@1.1.1";
+    url = "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz";
+    hash = "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==";
+  };
+  "@radix-ui/react-use-previous" = {
+    out_path = "@radix-ui/react-use-previous";
+    name = "@radix-ui/react-use-previous@1.1.1";
+    url = "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz";
+    hash = "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==";
+  };
+  "@radix-ui/react-use-rect" = {
+    out_path = "@radix-ui/react-use-rect";
+    name = "@radix-ui/react-use-rect@1.1.1";
+    url = "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz";
+    hash = "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==";
+  };
+  "@radix-ui/react-use-size" = {
+    out_path = "@radix-ui/react-use-size";
+    name = "@radix-ui/react-use-size@1.1.1";
+    url = "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz";
+    hash = "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==";
+  };
+  "@radix-ui/react-visually-hidden" = {
+    out_path = "@radix-ui/react-visually-hidden";
+    name = "@radix-ui/react-visually-hidden@1.2.3";
+    url = "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz";
+    hash = "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==";
+  };
+  "@radix-ui/rect" = {
+    out_path = "@radix-ui/rect";
+    name = "@radix-ui/rect@1.1.1";
+    url = "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz";
+    hash = "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==";
+  };
+  "@rolldown/pluginutils" = {
+    out_path = "@rolldown/pluginutils";
+    name = "@rolldown/pluginutils@1.0.0-beta.11";
+    url = "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.11.tgz";
+    hash = "sha512-L/gAA/hyCSuzTF1ftlzUSI/IKr2POHsv1Dd78GfqkR83KMNuswWD61JxGV2L7nRwBBBSDr6R1gCkdTmoN7W4ag==";
+  };
+  "@rollup/rollup-android-arm-eabi" = {
+    out_path = "@rollup/rollup-android-arm-eabi";
+    name = "@rollup/rollup-android-arm-eabi@4.43.0";
+    url = "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.43.0.tgz";
+    hash = "sha512-Krjy9awJl6rKbruhQDgivNbD1WuLb8xAclM4IR4cN5pHGAs2oIMMQJEiC3IC/9TZJ+QZkmZhlMO/6MBGxPidpw==";
+  };
+  "@rollup/rollup-android-arm64" = {
+    out_path = "@rollup/rollup-android-arm64";
+    name = "@rollup/rollup-android-arm64@4.43.0";
+    url = "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.43.0.tgz";
+    hash = "sha512-ss4YJwRt5I63454Rpj+mXCXicakdFmKnUNxr1dLK+5rv5FJgAxnN7s31a5VchRYxCFWdmnDWKd0wbAdTr0J5EA==";
+  };
+  "@rollup/rollup-darwin-arm64" = {
+    out_path = "@rollup/rollup-darwin-arm64";
+    name = "@rollup/rollup-darwin-arm64@4.43.0";
+    url = "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.43.0.tgz";
+    hash = "sha512-eKoL8ykZ7zz8MjgBenEF2OoTNFAPFz1/lyJ5UmmFSz5jW+7XbH1+MAgCVHy72aG59rbuQLcJeiMrP8qP5d/N0A==";
+  };
+  "@rollup/rollup-darwin-x64" = {
+    out_path = "@rollup/rollup-darwin-x64";
+    name = "@rollup/rollup-darwin-x64@4.43.0";
+    url = "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.43.0.tgz";
+    hash = "sha512-SYwXJgaBYW33Wi/q4ubN+ldWC4DzQY62S4Ll2dgfr/dbPoF50dlQwEaEHSKrQdSjC6oIe1WgzosoaNoHCdNuMg==";
+  };
+  "@rollup/rollup-freebsd-arm64" = {
+    out_path = "@rollup/rollup-freebsd-arm64";
+    name = "@rollup/rollup-freebsd-arm64@4.43.0";
+    url = "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.43.0.tgz";
+    hash = "sha512-SV+U5sSo0yujrjzBF7/YidieK2iF6E7MdF6EbYxNz94lA+R0wKl3SiixGyG/9Klab6uNBIqsN7j4Y/Fya7wAjQ==";
+  };
+  "@rollup/rollup-freebsd-x64" = {
+    out_path = "@rollup/rollup-freebsd-x64";
+    name = "@rollup/rollup-freebsd-x64@4.43.0";
+    url = "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.43.0.tgz";
+    hash = "sha512-J7uCsiV13L/VOeHJBo5SjasKiGxJ0g+nQTrBkAsmQBIdil3KhPnSE9GnRon4ejX1XDdsmK/l30IYLiAaQEO0Cg==";
+  };
+  "@rollup/rollup-linux-arm-gnueabihf" = {
+    out_path = "@rollup/rollup-linux-arm-gnueabihf";
+    name = "@rollup/rollup-linux-arm-gnueabihf@4.43.0";
+    url = "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.43.0.tgz";
+    hash = "sha512-gTJ/JnnjCMc15uwB10TTATBEhK9meBIY+gXP4s0sHD1zHOaIh4Dmy1X9wup18IiY9tTNk5gJc4yx9ctj/fjrIw==";
+  };
+  "@rollup/rollup-linux-arm-musleabihf" = {
+    out_path = "@rollup/rollup-linux-arm-musleabihf";
+    name = "@rollup/rollup-linux-arm-musleabihf@4.43.0";
+    url = "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.43.0.tgz";
+    hash = "sha512-ZJ3gZynL1LDSIvRfz0qXtTNs56n5DI2Mq+WACWZ7yGHFUEirHBRt7fyIk0NsCKhmRhn7WAcjgSkSVVxKlPNFFw==";
+  };
+  "@rollup/rollup-linux-arm64-gnu" = {
+    out_path = "@rollup/rollup-linux-arm64-gnu";
+    name = "@rollup/rollup-linux-arm64-gnu@4.43.0";
+    url = "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.43.0.tgz";
+    hash = "sha512-8FnkipasmOOSSlfucGYEu58U8cxEdhziKjPD2FIa0ONVMxvl/hmONtX/7y4vGjdUhjcTHlKlDhw3H9t98fPvyA==";
+  };
+  "@rollup/rollup-linux-arm64-musl" = {
+    out_path = "@rollup/rollup-linux-arm64-musl";
+    name = "@rollup/rollup-linux-arm64-musl@4.43.0";
+    url = "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.43.0.tgz";
+    hash = "sha512-KPPyAdlcIZ6S9C3S2cndXDkV0Bb1OSMsX0Eelr2Bay4EsF9yi9u9uzc9RniK3mcUGCLhWY9oLr6er80P5DE6XA==";
+  };
+  "@rollup/rollup-linux-loongarch64-gnu" = {
+    out_path = "@rollup/rollup-linux-loongarch64-gnu";
+    name = "@rollup/rollup-linux-loongarch64-gnu@4.43.0";
+    url = "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.43.0.tgz";
+    hash = "sha512-HPGDIH0/ZzAZjvtlXj6g+KDQ9ZMHfSP553za7o2Odegb/BEfwJcR0Sw0RLNpQ9nC6Gy8s+3mSS9xjZ0n3rhcYg==";
+  };
+  "@rollup/rollup-linux-powerpc64le-gnu" = {
+    out_path = "@rollup/rollup-linux-powerpc64le-gnu";
+    name = "@rollup/rollup-linux-powerpc64le-gnu@4.43.0";
+    url = "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.43.0.tgz";
+    hash = "sha512-gEmwbOws4U4GLAJDhhtSPWPXUzDfMRedT3hFMyRAvM9Mrnj+dJIFIeL7otsv2WF3D7GrV0GIewW0y28dOYWkmw==";
+  };
+  "@rollup/rollup-linux-riscv64-gnu" = {
+    out_path = "@rollup/rollup-linux-riscv64-gnu";
+    name = "@rollup/rollup-linux-riscv64-gnu@4.43.0";
+    url = "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.43.0.tgz";
+    hash = "sha512-XXKvo2e+wFtXZF/9xoWohHg+MuRnvO29TI5Hqe9xwN5uN8NKUYy7tXUG3EZAlfchufNCTHNGjEx7uN78KsBo0g==";
+  };
+  "@rollup/rollup-linux-riscv64-musl" = {
+    out_path = "@rollup/rollup-linux-riscv64-musl";
+    name = "@rollup/rollup-linux-riscv64-musl@4.43.0";
+    url = "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.43.0.tgz";
+    hash = "sha512-ruf3hPWhjw6uDFsOAzmbNIvlXFXlBQ4nk57Sec8E8rUxs/AI4HD6xmiiasOOx/3QxS2f5eQMKTAwk7KHwpzr/Q==";
+  };
+  "@rollup/rollup-linux-s390x-gnu" = {
+    out_path = "@rollup/rollup-linux-s390x-gnu";
+    name = "@rollup/rollup-linux-s390x-gnu@4.43.0";
+    url = "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.43.0.tgz";
+    hash = "sha512-QmNIAqDiEMEvFV15rsSnjoSmO0+eJLoKRD9EAa9rrYNwO/XRCtOGM3A5A0X+wmG+XRrw9Fxdsw+LnyYiZWWcVw==";
+  };
+  "@rollup/rollup-linux-x64-gnu" = {
+    out_path = "@rollup/rollup-linux-x64-gnu";
+    name = "@rollup/rollup-linux-x64-gnu@4.43.0";
+    url = "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.43.0.tgz";
+    hash = "sha512-jAHr/S0iiBtFyzjhOkAics/2SrXE092qyqEg96e90L3t9Op8OTzS6+IX0Fy5wCt2+KqeHAkti+eitV0wvblEoQ==";
+  };
+  "@rollup/rollup-linux-x64-musl" = {
+    out_path = "@rollup/rollup-linux-x64-musl";
+    name = "@rollup/rollup-linux-x64-musl@4.43.0";
+    url = "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.43.0.tgz";
+    hash = "sha512-3yATWgdeXyuHtBhrLt98w+5fKurdqvs8B53LaoKD7P7H7FKOONLsBVMNl9ghPQZQuYcceV5CDyPfyfGpMWD9mQ==";
+  };
+  "@rollup/rollup-win32-arm64-msvc" = {
+    out_path = "@rollup/rollup-win32-arm64-msvc";
+    name = "@rollup/rollup-win32-arm64-msvc@4.43.0";
+    url = "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.43.0.tgz";
+    hash = "sha512-wVzXp2qDSCOpcBCT5WRWLmpJRIzv23valvcTwMHEobkjippNf+C3ys/+wf07poPkeNix0paTNemB2XrHr2TnGw==";
+  };
+  "@rollup/rollup-win32-ia32-msvc" = {
+    out_path = "@rollup/rollup-win32-ia32-msvc";
+    name = "@rollup/rollup-win32-ia32-msvc@4.43.0";
+    url = "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.43.0.tgz";
+    hash = "sha512-fYCTEyzf8d+7diCw8b+asvWDCLMjsCEA8alvtAutqJOJp/wL5hs1rWSqJ1vkjgW0L2NB4bsYJrpKkiIPRR9dvw==";
+  };
+  "@rollup/rollup-win32-x64-msvc" = {
+    out_path = "@rollup/rollup-win32-x64-msvc";
+    name = "@rollup/rollup-win32-x64-msvc@4.43.0";
+    url = "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.43.0.tgz";
+    hash = "sha512-SnGhLiE5rlK0ofq8kzuDkM0g7FN1s5VYY+YSMTibP7CqShxCQvqtNxTARS4xX4PFJfHjG0ZQYX9iGzI3FQh5Aw==";
+  };
+  "@tailwindcss/cli" = {
+    out_path = "@tailwindcss/cli";
+    binaries = {
+      "tailwindcss" = "../@tailwindcss/cli/dist/index.mjs";
+    };
+    name = "@tailwindcss/cli@4.1.10";
+    url = "https://registry.npmjs.org/@tailwindcss/cli/-/cli-4.1.10.tgz";
+    hash = "sha512-TuO7IOUpTG1JeqtMQbQXjR4RIhfZ43mor/vpCp3S5X9h0WxUom5NYgxfNO0PiFoLMJ6/eYCelC7KGvUOmqqK6A==";
+  };
+  "@tailwindcss/node" = {
+    out_path = "@tailwindcss/node";
+    name = "@tailwindcss/node@4.1.10";
+    url = "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.10.tgz";
+    hash = "sha512-2ACf1znY5fpRBwRhMgj9ZXvb2XZW8qs+oTfotJ2C5xR0/WNL7UHZ7zXl6s+rUqedL1mNi+0O+WQr5awGowS3PQ==";
+  };
+  "@tailwindcss/oxide" = {
+    out_path = "@tailwindcss/oxide";
+    name = "@tailwindcss/oxide@4.1.10";
+    url = "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.10.tgz";
+    hash = "sha512-v0C43s7Pjw+B9w21htrQwuFObSkio2aV/qPx/mhrRldbqxbWJK6KizM+q7BF1/1CmuLqZqX3CeYF7s7P9fbA8Q==";
+  };
+  "@tailwindcss/oxide-android-arm64" = {
+    out_path = "@tailwindcss/oxide-android-arm64";
+    name = "@tailwindcss/oxide-android-arm64@4.1.10";
+    url = "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.10.tgz";
+    hash = "sha512-VGLazCoRQ7rtsCzThaI1UyDu/XRYVyH4/EWiaSX6tFglE+xZB5cvtC5Omt0OQ+FfiIVP98su16jDVHDEIuH4iQ==";
+  };
+  "@tailwindcss/oxide-darwin-arm64" = {
+    out_path = "@tailwindcss/oxide-darwin-arm64";
+    name = "@tailwindcss/oxide-darwin-arm64@4.1.10";
+    url = "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.10.tgz";
+    hash = "sha512-ZIFqvR1irX2yNjWJzKCqTCcHZbgkSkSkZKbRM3BPzhDL/18idA8uWCoopYA2CSDdSGFlDAxYdU2yBHwAwx8euQ==";
+  };
+  "@tailwindcss/oxide-darwin-x64" = {
+    out_path = "@tailwindcss/oxide-darwin-x64";
+    name = "@tailwindcss/oxide-darwin-x64@4.1.10";
+    url = "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.10.tgz";
+    hash = "sha512-eCA4zbIhWUFDXoamNztmS0MjXHSEJYlvATzWnRiTqJkcUteSjO94PoRHJy1Xbwp9bptjeIxxBHh+zBWFhttbrQ==";
+  };
+  "@tailwindcss/oxide-freebsd-x64" = {
+    out_path = "@tailwindcss/oxide-freebsd-x64";
+    name = "@tailwindcss/oxide-freebsd-x64@4.1.10";
+    url = "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.10.tgz";
+    hash = "sha512-8/392Xu12R0cc93DpiJvNpJ4wYVSiciUlkiOHOSOQNH3adq9Gi/dtySK7dVQjXIOzlpSHjeCL89RUUI8/GTI6g==";
+  };
+  "@tailwindcss/oxide-linux-arm-gnueabihf" = {
+    out_path = "@tailwindcss/oxide-linux-arm-gnueabihf";
+    name = "@tailwindcss/oxide-linux-arm-gnueabihf@4.1.10";
+    url = "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.10.tgz";
+    hash = "sha512-t9rhmLT6EqeuPT+MXhWhlRYIMSfh5LZ6kBrC4FS6/+M1yXwfCtp24UumgCWOAJVyjQwG+lYva6wWZxrfvB+NhQ==";
+  };
+  "@tailwindcss/oxide-linux-arm64-gnu" = {
+    out_path = "@tailwindcss/oxide-linux-arm64-gnu";
+    name = "@tailwindcss/oxide-linux-arm64-gnu@4.1.10";
+    url = "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.10.tgz";
+    hash = "sha512-3oWrlNlxLRxXejQ8zImzrVLuZ/9Z2SeKoLhtCu0hpo38hTO2iL86eFOu4sVR8cZc6n3z7eRXXqtHJECa6mFOvA==";
+  };
+  "@tailwindcss/oxide-linux-arm64-musl" = {
+    out_path = "@tailwindcss/oxide-linux-arm64-musl";
+    name = "@tailwindcss/oxide-linux-arm64-musl@4.1.10";
+    url = "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.10.tgz";
+    hash = "sha512-saScU0cmWvg/Ez4gUmQWr9pvY9Kssxt+Xenfx1LG7LmqjcrvBnw4r9VjkFcqmbBb7GCBwYNcZi9X3/oMda9sqQ==";
+  };
+  "@tailwindcss/oxide-linux-x64-gnu" = {
+    out_path = "@tailwindcss/oxide-linux-x64-gnu";
+    name = "@tailwindcss/oxide-linux-x64-gnu@4.1.10";
+    url = "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.10.tgz";
+    hash = "sha512-/G3ao/ybV9YEEgAXeEg28dyH6gs1QG8tvdN9c2MNZdUXYBaIY/Gx0N6RlJzfLy/7Nkdok4kaxKPHKJUlAaoTdA==";
+  };
+  "@tailwindcss/oxide-linux-x64-musl" = {
+    out_path = "@tailwindcss/oxide-linux-x64-musl";
+    name = "@tailwindcss/oxide-linux-x64-musl@4.1.10";
+    url = "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.10.tgz";
+    hash = "sha512-LNr7X8fTiKGRtQGOerSayc2pWJp/9ptRYAa4G+U+cjw9kJZvkopav1AQc5HHD+U364f71tZv6XamaHKgrIoVzA==";
+  };
+  "@tailwindcss/oxide-wasm32-wasi" = {
+    out_path = "@tailwindcss/oxide-wasm32-wasi";
+    name = "@tailwindcss/oxide-wasm32-wasi@4.1.10";
+    url = "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.10.tgz";
+    hash = "sha512-d6ekQpopFQJAcIK2i7ZzWOYGZ+A6NzzvQ3ozBvWFdeyqfOZdYHU66g5yr+/HC4ipP1ZgWsqa80+ISNILk+ae/Q==";
+  };
+  "@tailwindcss/oxide-wasm32-wasi/@emnapi/core" = {
+    out_path = "@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/node_modules/core";
+    name = "@emnapi/core@1.4.3";
+    url = "https://registry.npmjs.org/@emnapi/core/-/core-1.4.3.tgz";
+    hash = "sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==";
+  };
+  "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime" = {
+    out_path = "@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/node_modules/runtime";
+    name = "@emnapi/runtime@1.4.3";
+    url = "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.3.tgz";
+    hash = "sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==";
+  };
+  "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads" = {
+    out_path = "@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/node_modules/wasi-threads";
+    name = "@emnapi/wasi-threads@1.0.2";
+    url = "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.2.tgz";
+    hash = "sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==";
+  };
+  "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime" = {
+    out_path = "@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/node_modules/wasm-runtime";
+    name = "@napi-rs/wasm-runtime@0.2.11";
+    url = "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.11.tgz";
+    hash = "sha512-9DPkXtvHydrcOsopiYpUgPHpmj0HWZKMUnL2dZqpvC42lsratuBG06V5ipyno0fUek5VlFsNQ+AcFATSrJXgMA==";
+  };
+  "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util" = {
+    out_path = "@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/node_modules/wasm-util";
+    name = "@tybys/wasm-util@0.9.0";
+    url = "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz";
+    hash = "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==";
+  };
+  "@tailwindcss/oxide-wasm32-wasi/tslib" = {
+    out_path = "@tailwindcss/oxide-wasm32-wasi/node_modules/tslib";
+    name = "tslib@2.8.1";
+    url = "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz";
+    hash = "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==";
+  };
+  "@tailwindcss/oxide-win32-arm64-msvc" = {
+    out_path = "@tailwindcss/oxide-win32-arm64-msvc";
+    name = "@tailwindcss/oxide-win32-arm64-msvc@4.1.10";
+    url = "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.10.tgz";
+    hash = "sha512-i1Iwg9gRbwNVOCYmnigWCCgow8nDWSFmeTUU5nbNx3rqbe4p0kRbEqLwLJbYZKmSSp23g4N6rCDmm7OuPBXhDA==";
+  };
+  "@tailwindcss/oxide-win32-x64-msvc" = {
+    out_path = "@tailwindcss/oxide-win32-x64-msvc";
+    name = "@tailwindcss/oxide-win32-x64-msvc@4.1.10";
+    url = "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.10.tgz";
+    hash = "sha512-sGiJTjcBSfGq2DVRtaSljq5ZgZS2SDHSIfhOylkBvHVjwOsodBhnb3HdmiKkVuUGKD0I7G63abMOVaskj1KpOA==";
+  };
+  "@tailwindcss/vite" = {
+    out_path = "@tailwindcss/vite";
+    name = "@tailwindcss/vite@4.1.10";
+    url = "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.1.10.tgz";
+    hash = "sha512-QWnD5HDY2IADv+vYR82lOhqOlS1jSCUUAmfem52cXAhRTKxpDh3ARX8TTXJTCCO7Rv7cD2Nlekabv02bwP3a2A==";
+  };
+  "@tanstack/react-virtual" = {
+    out_path = "@tanstack/react-virtual";
+    name = "@tanstack/react-virtual@3.13.10";
+    url = "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.10.tgz";
+    hash = "sha512-nvrzk4E9mWB4124YdJ7/yzwou7IfHxlSef6ugCFcBfRmsnsma3heciiiV97sBNxyc3VuwtZvmwXd0aB5BpucVw==";
+  };
+  "@tanstack/virtual-core" = {
+    out_path = "@tanstack/virtual-core";
+    name = "@tanstack/virtual-core@3.13.10";
+    url = "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.10.tgz";
+    hash = "sha512-sPEDhXREou5HyZYqSWIqdU580rsF6FGeN7vpzijmP3KTiOGjOMZASz4Y6+QKjiFQwhWrR58OP8izYaNGVxvViA==";
+  };
+  "@tauri-apps/api" = {
+    out_path = "@tauri-apps/api";
+    name = "@tauri-apps/api@2.5.0";
+    url = "https://registry.npmjs.org/@tauri-apps/api/-/api-2.5.0.tgz";
+    hash = "sha512-Ldux4ip+HGAcPUmuLT8EIkk6yafl5vK0P0c0byzAKzxJh7vxelVtdPONjfgTm96PbN24yjZNESY8CKo8qniluA==";
+  };
+  "@tauri-apps/cli" = {
+    out_path = "@tauri-apps/cli";
+    binaries = {
+      "tauri" = "../@tauri-apps/cli/tauri.js";
+    };
+    name = "@tauri-apps/cli@2.5.0";
+    url = "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.5.0.tgz";
+    hash = "sha512-rAtHqG0Gh/IWLjN2zTf3nZqYqbo81oMbqop56rGTjrlWk9pTTAjkqOjSL9XQLIMZ3RbeVjveCqqCA0s8RnLdMg==";
+  };
+  "@tauri-apps/cli-darwin-arm64" = {
+    out_path = "@tauri-apps/cli-darwin-arm64";
+    name = "@tauri-apps/cli-darwin-arm64@2.5.0";
+    url = "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.5.0.tgz";
+    hash = "sha512-VuVAeTFq86dfpoBDNYAdtQVLbP0+2EKCHIIhkaxjeoPARR0sLpFHz2zs0PcFU76e+KAaxtEtAJAXGNUc8E1PzQ==";
+  };
+  "@tauri-apps/cli-darwin-x64" = {
+    out_path = "@tauri-apps/cli-darwin-x64";
+    name = "@tauri-apps/cli-darwin-x64@2.5.0";
+    url = "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.5.0.tgz";
+    hash = "sha512-hUF01sC06cZVa8+I0/VtsHOk9BbO75rd+YdtHJ48xTdcYaQ5QIwL4yZz9OR1AKBTaUYhBam8UX9Pvd5V2/4Dpw==";
+  };
+  "@tauri-apps/cli-linux-arm-gnueabihf" = {
+    out_path = "@tauri-apps/cli-linux-arm-gnueabihf";
+    name = "@tauri-apps/cli-linux-arm-gnueabihf@2.5.0";
+    url = "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.5.0.tgz";
+    hash = "sha512-LQKqttsK252LlqYyX8R02MinUsfFcy3+NZiJwHFgi5Y3+ZUIAED9cSxJkyNtuY5KMnR4RlpgWyLv4P6akN1xhg==";
+  };
+  "@tauri-apps/cli-linux-arm64-gnu" = {
+    out_path = "@tauri-apps/cli-linux-arm64-gnu";
+    name = "@tauri-apps/cli-linux-arm64-gnu@2.5.0";
+    url = "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.5.0.tgz";
+    hash = "sha512-mTQufsPcpdHg5RW0zypazMo4L55EfeE5snTzrPqbLX4yCK2qalN7+rnP8O8GT06xhp6ElSP/Ku1M2MR297SByQ==";
+  };
+  "@tauri-apps/cli-linux-arm64-musl" = {
+    out_path = "@tauri-apps/cli-linux-arm64-musl";
+    name = "@tauri-apps/cli-linux-arm64-musl@2.5.0";
+    url = "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.0.tgz";
+    hash = "sha512-rQO1HhRUQqyEaal5dUVOQruTRda/TD36s9kv1hTxZiFuSq3558lsTjAcUEnMAtBcBkps20sbyTJNMT0AwYIk8Q==";
+  };
+  "@tauri-apps/cli-linux-riscv64-gnu" = {
+    out_path = "@tauri-apps/cli-linux-riscv64-gnu";
+    name = "@tauri-apps/cli-linux-riscv64-gnu@2.5.0";
+    url = "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.5.0.tgz";
+    hash = "sha512-7oS18FN46yDxyw1zX/AxhLAd7T3GrLj3Ai6s8hZKd9qFVzrAn36ESL7d3G05s8wEtsJf26qjXnVF4qleS3dYsA==";
+  };
+  "@tauri-apps/cli-linux-x64-gnu" = {
+    out_path = "@tauri-apps/cli-linux-x64-gnu";
+    name = "@tauri-apps/cli-linux-x64-gnu@2.5.0";
+    url = "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.5.0.tgz";
+    hash = "sha512-SG5sFNL7VMmDBdIg3nO3EzNRT306HsiEQ0N90ILe3ZABYAVoPDO/ttpCO37ApLInTzrq/DLN+gOlC/mgZvLw1w==";
+  };
+  "@tauri-apps/cli-linux-x64-musl" = {
+    out_path = "@tauri-apps/cli-linux-x64-musl";
+    name = "@tauri-apps/cli-linux-x64-musl@2.5.0";
+    url = "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.0.tgz";
+    hash = "sha512-QXDM8zp/6v05PNWju5ELsVwF0VH1n6b5pk2E6W/jFbbiwz80Vs1lACl9pv5kEHkrxBj+aWU/03JzGuIj2g3SkQ==";
+  };
+  "@tauri-apps/cli-win32-arm64-msvc" = {
+    out_path = "@tauri-apps/cli-win32-arm64-msvc";
+    name = "@tauri-apps/cli-win32-arm64-msvc@2.5.0";
+    url = "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.5.0.tgz";
+    hash = "sha512-pFSHFK6b+o9y4Un8w0gGLwVyFTZaC3P0kQ7umRt/BLDkzD5RnQ4vBM7CF8BCU5nkwmEBUCZd7Wt3TWZxe41o6Q==";
+  };
+  "@tauri-apps/cli-win32-ia32-msvc" = {
+    out_path = "@tauri-apps/cli-win32-ia32-msvc";
+    name = "@tauri-apps/cli-win32-ia32-msvc@2.5.0";
+    url = "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.5.0.tgz";
+    hash = "sha512-EArv1IaRlogdLAQyGlKmEqZqm5RfHCUMhJoedWu7GtdbOMUfSAz6FMX2boE1PtEmNO4An+g188flLeVErrxEKg==";
+  };
+  "@tauri-apps/cli-win32-x64-msvc" = {
+    out_path = "@tauri-apps/cli-win32-x64-msvc";
+    name = "@tauri-apps/cli-win32-x64-msvc@2.5.0";
+    url = "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.5.0.tgz";
+    hash = "sha512-lj43EFYbnAta8pd9JnUq87o+xRUR0odz+4rixBtTUwUgdRdwQ2V9CzFtsMu6FQKpFQ6mujRK6P1IEwhL6ADRsQ==";
+  };
+  "@tauri-apps/plugin-dialog" = {
+    out_path = "@tauri-apps/plugin-dialog";
+    name = "@tauri-apps/plugin-dialog@2.2.2";
+    url = "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.2.2.tgz";
+    hash = "sha512-Pm9qnXQq8ZVhAMFSEPwxvh+nWb2mk7LASVlNEHYaksHvcz8P6+ElR5U5dNL9Ofrm+uwhh1/gYKWswK8JJJAh6A==";
+  };
+  "@tauri-apps/plugin-global-shortcut" = {
+    out_path = "@tauri-apps/plugin-global-shortcut";
+    name = "@tauri-apps/plugin-global-shortcut@2.2.1";
+    url = "https://registry.npmjs.org/@tauri-apps/plugin-global-shortcut/-/plugin-global-shortcut-2.2.1.tgz";
+    hash = "sha512-b64/TI1t5LIi2JY4OWlYjZpPRq60T5GVVL/no27sUuxaNUZY8dVtwsMtDUgxUpln2yR+P2PJsYlqY5V8sLSxEw==";
+  };
+  "@tauri-apps/plugin-opener" = {
+    out_path = "@tauri-apps/plugin-opener";
+    name = "@tauri-apps/plugin-opener@2.3.0";
+    url = "https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.3.0.tgz";
+    hash = "sha512-yAbauwp8BCHIhhA48NN8rEf6OtfZBPCgTOCa10gmtoVCpmic5Bq+1Ba7C+NZOjogedkSiV7hAotjYnnbUVmYrw==";
+  };
+  "@tauri-apps/plugin-shell" = {
+    out_path = "@tauri-apps/plugin-shell";
+    name = "@tauri-apps/plugin-shell@2.2.2";
+    url = "https://registry.npmjs.org/@tauri-apps/plugin-shell/-/plugin-shell-2.2.2.tgz";
+    hash = "sha512-fg9XKWfzRQsN8p+Zrk82WeHvXFvGVnG0/mTlujQdLWNnO5cM6WD9qCrHbFytScVS+WhmRAkuypQPcxeKKl3VBg==";
+  };
+  "@types/babel__core" = {
+    out_path = "@types/babel__core";
+    name = "@types/babel__core@7.20.5";
+    url = "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz";
+    hash = "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==";
+  };
+  "@types/babel__generator" = {
+    out_path = "@types/babel__generator";
+    name = "@types/babel__generator@7.27.0";
+    url = "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz";
+    hash = "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==";
+  };
+  "@types/babel__template" = {
+    out_path = "@types/babel__template";
+    name = "@types/babel__template@7.4.4";
+    url = "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz";
+    hash = "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==";
+  };
+  "@types/babel__traverse" = {
+    out_path = "@types/babel__traverse";
+    name = "@types/babel__traverse@7.20.7";
+    url = "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.7.tgz";
+    hash = "sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==";
+  };
+  "@types/d3-array" = {
+    out_path = "@types/d3-array";
+    name = "@types/d3-array@3.2.1";
+    url = "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz";
+    hash = "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==";
+  };
+  "@types/d3-color" = {
+    out_path = "@types/d3-color";
+    name = "@types/d3-color@3.1.3";
+    url = "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz";
+    hash = "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==";
+  };
+  "@types/d3-ease" = {
+    out_path = "@types/d3-ease";
+    name = "@types/d3-ease@3.0.2";
+    url = "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz";
+    hash = "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==";
+  };
+  "@types/d3-interpolate" = {
+    out_path = "@types/d3-interpolate";
+    name = "@types/d3-interpolate@3.0.4";
+    url = "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz";
+    hash = "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==";
+  };
+  "@types/d3-path" = {
+    out_path = "@types/d3-path";
+    name = "@types/d3-path@3.1.1";
+    url = "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz";
+    hash = "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==";
+  };
+  "@types/d3-scale" = {
+    out_path = "@types/d3-scale";
+    name = "@types/d3-scale@4.0.9";
+    url = "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz";
+    hash = "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==";
+  };
+  "@types/d3-shape" = {
+    out_path = "@types/d3-shape";
+    name = "@types/d3-shape@3.1.7";
+    url = "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz";
+    hash = "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==";
+  };
+  "@types/d3-time" = {
+    out_path = "@types/d3-time";
+    name = "@types/d3-time@3.0.4";
+    url = "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz";
+    hash = "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==";
+  };
+  "@types/d3-timer" = {
+    out_path = "@types/d3-timer";
+    name = "@types/d3-timer@3.0.2";
+    url = "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz";
+    hash = "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==";
+  };
+  "@types/debug" = {
+    out_path = "@types/debug";
+    name = "@types/debug@4.1.12";
+    url = "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz";
+    hash = "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==";
+  };
+  "@types/diff" = {
+    out_path = "@types/diff";
+    name = "@types/diff@8.0.0";
+    url = "https://registry.npmjs.org/@types/diff/-/diff-8.0.0.tgz";
+    hash = "sha512-o7jqJM04gfaYrdCecCVMbZhNdG6T1MHg/oQoRFdERLV+4d+V7FijhiEAbFu0Usww84Yijk9yH58U4Jk4HbtzZw==";
+  };
+  "@types/estree" = {
+    out_path = "@types/estree";
+    name = "@types/estree@1.0.7";
+    url = "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz";
+    hash = "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==";
+  };
+  "@types/estree-jsx" = {
+    out_path = "@types/estree-jsx";
+    name = "@types/estree-jsx@1.0.5";
+    url = "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz";
+    hash = "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==";
+  };
+  "@types/hast" = {
+    out_path = "@types/hast";
+    name = "@types/hast@3.0.4";
+    url = "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz";
+    hash = "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==";
+  };
+  "@types/mdast" = {
+    out_path = "@types/mdast";
+    name = "@types/mdast@4.0.4";
+    url = "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz";
+    hash = "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==";
+  };
+  "@types/ms" = {
+    out_path = "@types/ms";
+    name = "@types/ms@2.1.0";
+    url = "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz";
+    hash = "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==";
+  };
+  "@types/node" = {
+    out_path = "@types/node";
+    name = "@types/node@22.15.32";
+    url = "https://registry.npmjs.org/@types/node/-/node-22.15.32.tgz";
+    hash = "sha512-3jigKqgSjsH6gYZv2nEsqdXfZqIFGAV36XYYjf9KGZ3PSG+IhLecqPnI310RvjutyMwifE2hhhNEklOUrvx/wA==";
+  };
+  "@types/prismjs" = {
+    out_path = "@types/prismjs";
+    name = "@types/prismjs@1.26.5";
+    url = "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.5.tgz";
+    hash = "sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==";
+  };
+  "@types/prop-types" = {
+    out_path = "@types/prop-types";
+    name = "@types/prop-types@15.7.15";
+    url = "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz";
+    hash = "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==";
+  };
+  "@types/react" = {
+    out_path = "@types/react";
+    name = "@types/react@18.3.23";
+    url = "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz";
+    hash = "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==";
+  };
+  "@types/react-dom" = {
+    out_path = "@types/react-dom";
+    name = "@types/react-dom@18.3.7";
+    url = "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz";
+    hash = "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==";
+  };
+  "@types/react-syntax-highlighter" = {
+    out_path = "@types/react-syntax-highlighter";
+    name = "@types/react-syntax-highlighter@15.5.13";
+    url = "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.13.tgz";
+    hash = "sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==";
+  };
+  "@types/sharp" = {
+    out_path = "@types/sharp";
+    name = "@types/sharp@0.32.0";
+    url = "https://registry.npmjs.org/@types/sharp/-/sharp-0.32.0.tgz";
+    hash = "sha512-OOi3kL+FZDnPhVzsfD37J88FNeZh6gQsGcLc95NbeURRGvmSjeXiDcyWzF2o3yh/gQAUn2uhh/e+CPCa5nwAxw==";
+  };
+  "@types/unist" = {
+    out_path = "@types/unist";
+    name = "@types/unist@3.0.3";
+    url = "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz";
+    hash = "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==";
+  };
+  "@uiw/copy-to-clipboard" = {
+    out_path = "@uiw/copy-to-clipboard";
+    name = "@uiw/copy-to-clipboard@1.0.17";
+    url = "https://registry.npmjs.org/@uiw/copy-to-clipboard/-/copy-to-clipboard-1.0.17.tgz";
+    hash = "sha512-O2GUHV90Iw2VrSLVLK0OmNIMdZ5fgEg4NhvtwINsX+eZ/Wf6DWD0TdsK9xwV7dNRnK/UI2mQtl0a2/kRgm1m1A==";
+  };
+  "@uiw/react-markdown-preview" = {
+    out_path = "@uiw/react-markdown-preview";
+    name = "@uiw/react-markdown-preview@5.1.4";
+    url = "https://registry.npmjs.org/@uiw/react-markdown-preview/-/react-markdown-preview-5.1.4.tgz";
+    hash = "sha512-6k13WVNHCEaamz3vh54OQ1tseIXneKlir1+E/VFQBPq8PRod+gwLfYtiitDBWu+ZFttoiKPLZ7flgHrVM+JNOg==";
+  };
+  "@uiw/react-markdown-preview/react-markdown" = {
+    out_path = "@uiw/react-markdown-preview/node_modules/react-markdown";
+    name = "react-markdown@9.0.3";
+    url = "https://registry.npmjs.org/react-markdown/-/react-markdown-9.0.3.tgz";
+    hash = "sha512-Yk7Z94dbgYTOrdk41Z74GoKA7rThnsbbqBTRYuxoe08qvfQ9tJVhmAKw6BJS/ZORG7kTy/s1QvYzSuaoBA1qfw==";
+  };
+  "@uiw/react-markdown-preview/rehype-prism-plus" = {
+    out_path = "@uiw/react-markdown-preview/node_modules/rehype-prism-plus";
+    name = "rehype-prism-plus@2.0.0";
+    url = "https://registry.npmjs.org/rehype-prism-plus/-/rehype-prism-plus-2.0.0.tgz";
+    hash = "sha512-FeM/9V2N7EvDZVdR2dqhAzlw5YI49m9Tgn7ZrYJeYHIahM6gcXpH0K1y2gNnKanZCydOMluJvX2cB9z3lhY8XQ==";
+  };
+  "@uiw/react-markdown-preview/rehype-prism-plus/refractor" = {
+    out_path = "@uiw/react-markdown-preview/node_modules/rehype-prism-plus/node_modules/refractor";
+    name = "refractor@4.9.0";
+    url = "https://registry.npmjs.org/refractor/-/refractor-4.9.0.tgz";
+    hash = "sha512-nEG1SPXFoGGx+dcjftjv8cAjEusIh6ED1xhf5DG3C0x/k+rmZ2duKnc3QLpt6qeHv5fPb8uwN3VWN2BT7fr3Og==";
+  };
+  "@uiw/react-markdown-preview/rehype-prism-plus/refractor/@types/hast" = {
+    out_path = "@uiw/react-markdown-preview/node_modules/rehype-prism-plus/node_modules/refractor/node_modules/@types/node_modules/hast";
+    name = "@types/hast@2.3.10";
+    url = "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz";
+    hash = "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==";
+  };
+  "@uiw/react-markdown-preview/rehype-prism-plus/refractor/@types/hast/@types/unist" = {
+    out_path = "@uiw/react-markdown-preview/node_modules/rehype-prism-plus/node_modules/refractor/node_modules/@types/node_modules/hast/node_modules/@types/node_modules/unist";
+    name = "@types/unist@2.0.11";
+    url = "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz";
+    hash = "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==";
+  };
+  "@uiw/react-markdown-preview/rehype-prism-plus/refractor/hastscript" = {
+    out_path = "@uiw/react-markdown-preview/node_modules/rehype-prism-plus/node_modules/refractor/node_modules/hastscript";
+    name = "hastscript@7.2.0";
+    url = "https://registry.npmjs.org/hastscript/-/hastscript-7.2.0.tgz";
+    hash = "sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==";
+  };
+  "@uiw/react-markdown-preview/rehype-prism-plus/refractor/hastscript/hast-util-parse-selector" = {
+    out_path = "@uiw/react-markdown-preview/node_modules/rehype-prism-plus/node_modules/refractor/node_modules/hastscript/node_modules/hast-util-parse-selector";
+    name = "hast-util-parse-selector@3.1.1";
+    url = "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-3.1.1.tgz";
+    hash = "sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==";
+  };
+  "@uiw/react-markdown-preview/rehype-prism-plus/refractor/hastscript/property-information" = {
+    out_path = "@uiw/react-markdown-preview/node_modules/rehype-prism-plus/node_modules/refractor/node_modules/hastscript/node_modules/property-information";
+    name = "property-information@6.5.0";
+    url = "https://registry.npmjs.org/property-information/-/property-information-6.5.0.tgz";
+    hash = "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==";
+  };
+  "@uiw/react-markdown-preview/rehype-prism-plus/refractor/parse-entities" = {
+    out_path = "@uiw/react-markdown-preview/node_modules/rehype-prism-plus/node_modules/refractor/node_modules/parse-entities";
+    name = "parse-entities@4.0.2";
+    url = "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz";
+    hash = "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==";
+  };
+  "@uiw/react-markdown-preview/rehype-prism-plus/refractor/parse-entities/@types/unist" = {
+    out_path = "@uiw/react-markdown-preview/node_modules/rehype-prism-plus/node_modules/refractor/node_modules/parse-entities/node_modules/@types/node_modules/unist";
+    name = "@types/unist@2.0.11";
+    url = "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz";
+    hash = "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==";
+  };
+  "@uiw/react-markdown-preview/rehype-prism-plus/refractor/parse-entities/character-entities-legacy" = {
+    out_path = "@uiw/react-markdown-preview/node_modules/rehype-prism-plus/node_modules/refractor/node_modules/parse-entities/node_modules/character-entities-legacy";
+    name = "character-entities-legacy@3.0.0";
+    url = "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz";
+    hash = "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==";
+  };
+  "@uiw/react-markdown-preview/rehype-prism-plus/refractor/parse-entities/character-reference-invalid" = {
+    out_path = "@uiw/react-markdown-preview/node_modules/rehype-prism-plus/node_modules/refractor/node_modules/parse-entities/node_modules/character-reference-invalid";
+    name = "character-reference-invalid@2.0.1";
+    url = "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz";
+    hash = "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==";
+  };
+  "@uiw/react-markdown-preview/rehype-prism-plus/refractor/parse-entities/is-alphanumerical" = {
+    out_path = "@uiw/react-markdown-preview/node_modules/rehype-prism-plus/node_modules/refractor/node_modules/parse-entities/node_modules/is-alphanumerical";
+    name = "is-alphanumerical@2.0.1";
+    url = "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz";
+    hash = "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==";
+  };
+  "@uiw/react-markdown-preview/rehype-prism-plus/refractor/parse-entities/is-alphanumerical/is-alphabetical" = {
+    out_path = "@uiw/react-markdown-preview/node_modules/rehype-prism-plus/node_modules/refractor/node_modules/parse-entities/node_modules/is-alphanumerical/node_modules/is-alphabetical";
+    name = "is-alphabetical@2.0.1";
+    url = "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz";
+    hash = "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==";
+  };
+  "@uiw/react-markdown-preview/rehype-prism-plus/refractor/parse-entities/is-decimal" = {
+    out_path = "@uiw/react-markdown-preview/node_modules/rehype-prism-plus/node_modules/refractor/node_modules/parse-entities/node_modules/is-decimal";
+    name = "is-decimal@2.0.1";
+    url = "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz";
+    hash = "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==";
+  };
+  "@uiw/react-markdown-preview/rehype-prism-plus/refractor/parse-entities/is-hexadecimal" = {
+    out_path = "@uiw/react-markdown-preview/node_modules/rehype-prism-plus/node_modules/refractor/node_modules/parse-entities/node_modules/is-hexadecimal";
+    name = "is-hexadecimal@2.0.1";
+    url = "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz";
+    hash = "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==";
+  };
+  "@uiw/react-md-editor" = {
+    out_path = "@uiw/react-md-editor";
+    name = "@uiw/react-md-editor@4.0.7";
+    url = "https://registry.npmjs.org/@uiw/react-md-editor/-/react-md-editor-4.0.7.tgz";
+    hash = "sha512-fKUJDo/f6ty1R5CRfYCIgt2eWNCWnwkEZhj65zv3cLsywAw13rsOL0/TuG8khpcV9mSnDHPWAz43xgKcjk5VJA==";
+  };
+  "@ungap/structured-clone" = {
+    out_path = "@ungap/structured-clone";
+    name = "@ungap/structured-clone@1.3.0";
+    url = "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz";
+    hash = "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==";
+  };
+  "@vitejs/plugin-react" = {
+    out_path = "@vitejs/plugin-react";
+    name = "@vitejs/plugin-react@4.5.2";
+    url = "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.5.2.tgz";
+    hash = "sha512-QNVT3/Lxx99nMQWJWF7K4N6apUEuT0KlZA3mx/mVaoGj3smm/8rc8ezz15J1pcbcjDK0V15rpHetVfya08r76Q==";
+  };
+  "ansi-to-html" = {
+    out_path = "ansi-to-html";
+    binaries = {
+      "ansi-to-html" = "../ansi-to-html/bin/ansi-to-html";
+    };
+    name = "ansi-to-html@0.7.2";
+    url = "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.7.2.tgz";
+    hash = "sha512-v6MqmEpNlxF+POuyhKkidusCHWWkaLcGRURzivcU3I9tv7k4JVhFcnukrM5Rlk2rUywdZuzYAZ+kbZqWCnfN3g==";
+  };
+  "aria-hidden" = {
+    out_path = "aria-hidden";
+    name = "aria-hidden@1.2.6";
+    url = "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz";
+    hash = "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==";
+  };
+  "bail" = {
+    out_path = "bail";
+    name = "bail@2.0.2";
+    url = "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz";
+    hash = "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==";
+  };
+  "base64-arraybuffer" = {
+    out_path = "base64-arraybuffer";
+    name = "base64-arraybuffer@1.0.2";
+    url = "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz";
+    hash = "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==";
+  };
+  "bcp-47-match" = {
+    out_path = "bcp-47-match";
+    name = "bcp-47-match@2.0.3";
+    url = "https://registry.npmjs.org/bcp-47-match/-/bcp-47-match-2.0.3.tgz";
+    hash = "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==";
+  };
+  "boolbase" = {
+    out_path = "boolbase";
+    name = "boolbase@1.0.0";
+    url = "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz";
+    hash = "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==";
+  };
+  "braces" = {
+    out_path = "braces";
+    name = "braces@3.0.3";
+    url = "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz";
+    hash = "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==";
+  };
+  "browserslist" = {
+    out_path = "browserslist";
+    binaries = {
+      "browserslist" = "../browserslist/cli.js";
+    };
+    name = "browserslist@4.25.0";
+    url = "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz";
+    hash = "sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==";
+  };
+  "caniuse-lite" = {
+    out_path = "caniuse-lite";
+    name = "caniuse-lite@1.0.30001723";
+    url = "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001723.tgz";
+    hash = "sha512-1R/elMjtehrFejxwmexeXAtae5UO9iSyFn6G/I806CYC/BLyyBk1EPhrKBkWhy6wM6Xnm47dSJQec+tLJ39WHw==";
+  };
+  "ccount" = {
+    out_path = "ccount";
+    name = "ccount@2.0.1";
+    url = "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz";
+    hash = "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==";
+  };
+  "character-entities" = {
+    out_path = "character-entities";
+    name = "character-entities@1.2.4";
+    url = "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz";
+    hash = "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==";
+  };
+  "character-entities-html4" = {
+    out_path = "character-entities-html4";
+    name = "character-entities-html4@2.1.0";
+    url = "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz";
+    hash = "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==";
+  };
+  "character-entities-legacy" = {
+    out_path = "character-entities-legacy";
+    name = "character-entities-legacy@1.1.4";
+    url = "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz";
+    hash = "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==";
+  };
+  "character-reference-invalid" = {
+    out_path = "character-reference-invalid";
+    name = "character-reference-invalid@1.1.4";
+    url = "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz";
+    hash = "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==";
+  };
+  "chownr" = {
+    out_path = "chownr";
+    name = "chownr@3.0.0";
+    url = "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz";
+    hash = "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==";
+  };
+  "class-variance-authority" = {
+    out_path = "class-variance-authority";
+    name = "class-variance-authority@0.7.1";
+    url = "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz";
+    hash = "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==";
+  };
+  "clsx" = {
+    out_path = "clsx";
+    name = "clsx@2.1.1";
+    url = "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz";
+    hash = "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==";
+  };
+  "color" = {
+    out_path = "color";
+    name = "color@4.2.3";
+    url = "https://registry.npmjs.org/color/-/color-4.2.3.tgz";
+    hash = "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==";
+  };
+  "color-convert" = {
+    out_path = "color-convert";
+    name = "color-convert@2.0.1";
+    url = "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz";
+    hash = "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==";
+  };
+  "color-name" = {
+    out_path = "color-name";
+    name = "color-name@1.1.4";
+    url = "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz";
+    hash = "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==";
+  };
+  "color-string" = {
+    out_path = "color-string";
+    name = "color-string@1.9.1";
+    url = "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz";
+    hash = "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==";
+  };
+  "comma-separated-tokens" = {
+    out_path = "comma-separated-tokens";
+    name = "comma-separated-tokens@2.0.3";
+    url = "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz";
+    hash = "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==";
+  };
+  "convert-source-map" = {
+    out_path = "convert-source-map";
+    name = "convert-source-map@2.0.0";
+    url = "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz";
+    hash = "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==";
+  };
+  "css-line-break" = {
+    out_path = "css-line-break";
+    name = "css-line-break@2.1.0";
+    url = "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz";
+    hash = "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==";
+  };
+  "css-selector-parser" = {
+    out_path = "css-selector-parser";
+    name = "css-selector-parser@3.1.2";
+    url = "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-3.1.2.tgz";
+    hash = "sha512-WfUcL99xWDs7b3eZPoRszWVfbNo8ErCF15PTvVROjkShGlAfjIkG6hlfj/sl6/rfo5Q9x9ryJ3VqVnAZDA+gcw==";
+  };
+  "csstype" = {
+    out_path = "csstype";
+    name = "csstype@3.1.3";
+    url = "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz";
+    hash = "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==";
+  };
+  "d3-array" = {
+    out_path = "d3-array";
+    name = "d3-array@3.2.4";
+    url = "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz";
+    hash = "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==";
+  };
+  "d3-color" = {
+    out_path = "d3-color";
+    name = "d3-color@3.1.0";
+    url = "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz";
+    hash = "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==";
+  };
+  "d3-ease" = {
+    out_path = "d3-ease";
+    name = "d3-ease@3.0.1";
+    url = "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz";
+    hash = "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==";
+  };
+  "d3-format" = {
+    out_path = "d3-format";
+    name = "d3-format@3.1.0";
+    url = "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz";
+    hash = "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==";
+  };
+  "d3-interpolate" = {
+    out_path = "d3-interpolate";
+    name = "d3-interpolate@3.0.1";
+    url = "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz";
+    hash = "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==";
+  };
+  "d3-path" = {
+    out_path = "d3-path";
+    name = "d3-path@3.1.0";
+    url = "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz";
+    hash = "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==";
+  };
+  "d3-scale" = {
+    out_path = "d3-scale";
+    name = "d3-scale@4.0.2";
+    url = "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz";
+    hash = "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==";
+  };
+  "d3-shape" = {
+    out_path = "d3-shape";
+    name = "d3-shape@3.2.0";
+    url = "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz";
+    hash = "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==";
+  };
+  "d3-time" = {
+    out_path = "d3-time";
+    name = "d3-time@3.1.0";
+    url = "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz";
+    hash = "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==";
+  };
+  "d3-time-format" = {
+    out_path = "d3-time-format";
+    name = "d3-time-format@4.1.0";
+    url = "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz";
+    hash = "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==";
+  };
+  "d3-timer" = {
+    out_path = "d3-timer";
+    name = "d3-timer@3.0.1";
+    url = "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz";
+    hash = "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==";
+  };
+  "date-fns" = {
+    out_path = "date-fns";
+    name = "date-fns@3.6.0";
+    url = "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz";
+    hash = "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==";
+  };
+  "debug" = {
+    out_path = "debug";
+    name = "debug@4.4.1";
+    url = "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz";
+    hash = "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==";
+  };
+  "decimal.js-light" = {
+    out_path = "decimal.js-light";
+    name = "decimal.js-light@2.5.1";
+    url = "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz";
+    hash = "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==";
+  };
+  "decode-named-character-reference" = {
+    out_path = "decode-named-character-reference";
+    name = "decode-named-character-reference@1.2.0";
+    url = "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz";
+    hash = "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==";
+  };
+  "decode-named-character-reference/character-entities" = {
+    out_path = "decode-named-character-reference/node_modules/character-entities";
+    name = "character-entities@2.0.2";
+    url = "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz";
+    hash = "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==";
+  };
+  "dequal" = {
+    out_path = "dequal";
+    name = "dequal@2.0.3";
+    url = "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz";
+    hash = "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==";
+  };
+  "detect-libc" = {
+    out_path = "detect-libc";
+    name = "detect-libc@2.0.4";
+    url = "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz";
+    hash = "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==";
+  };
+  "detect-node-es" = {
+    out_path = "detect-node-es";
+    name = "detect-node-es@1.1.0";
+    url = "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz";
+    hash = "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==";
+  };
+  "devlop" = {
+    out_path = "devlop";
+    name = "devlop@1.1.0";
+    url = "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz";
+    hash = "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==";
+  };
+  "diff" = {
+    out_path = "diff";
+    name = "diff@8.0.2";
+    url = "https://registry.npmjs.org/diff/-/diff-8.0.2.tgz";
+    hash = "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==";
+  };
+  "direction" = {
+    out_path = "direction";
+    binaries = {
+      "direction" = "../direction/cli.js";
+    };
+    name = "direction@2.0.1";
+    url = "https://registry.npmjs.org/direction/-/direction-2.0.1.tgz";
+    hash = "sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==";
+  };
+  "dom-helpers" = {
+    out_path = "dom-helpers";
+    name = "dom-helpers@5.2.1";
+    url = "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz";
+    hash = "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==";
+  };
+  "electron-to-chromium" = {
+    out_path = "electron-to-chromium";
+    name = "electron-to-chromium@1.5.169";
+    url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.169.tgz";
+    hash = "sha512-q7SQx6mkLy0GTJK9K9OiWeaBMV4XQtBSdf6MJUzDB/H/5tFXfIiX38Lci1Kl6SsgiEhz1SQI1ejEOU5asWEhwQ==";
+  };
+  "enhanced-resolve" = {
+    out_path = "enhanced-resolve";
+    name = "enhanced-resolve@5.18.1";
+    url = "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz";
+    hash = "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==";
+  };
+  "entities" = {
+    out_path = "entities";
+    name = "entities@2.2.0";
+    url = "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz";
+    hash = "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==";
+  };
+  "esbuild" = {
+    out_path = "esbuild";
+    binaries = {
+      "esbuild" = "../esbuild/bin/esbuild";
+    };
+    name = "esbuild@0.25.5";
+    url = "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz";
+    hash = "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==";
+  };
+  "escalade" = {
+    out_path = "escalade";
+    name = "escalade@3.2.0";
+    url = "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz";
+    hash = "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==";
+  };
+  "escape-string-regexp" = {
+    out_path = "escape-string-regexp";
+    name = "escape-string-regexp@5.0.0";
+    url = "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz";
+    hash = "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==";
+  };
+  "estree-util-is-identifier-name" = {
+    out_path = "estree-util-is-identifier-name";
+    name = "estree-util-is-identifier-name@3.0.0";
+    url = "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz";
+    hash = "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==";
+  };
+  "eventemitter3" = {
+    out_path = "eventemitter3";
+    name = "eventemitter3@4.0.7";
+    url = "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz";
+    hash = "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==";
+  };
+  "extend" = {
+    out_path = "extend";
+    name = "extend@3.0.2";
+    url = "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz";
+    hash = "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==";
+  };
+  "fast-equals" = {
+    out_path = "fast-equals";
+    name = "fast-equals@5.2.2";
+    url = "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz";
+    hash = "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==";
+  };
+  "fault" = {
+    out_path = "fault";
+    name = "fault@1.0.4";
+    url = "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz";
+    hash = "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==";
+  };
+  "fdir" = {
+    out_path = "fdir";
+    name = "fdir@6.4.6";
+    url = "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz";
+    hash = "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==";
+  };
+  "fill-range" = {
+    out_path = "fill-range";
+    name = "fill-range@7.1.1";
+    url = "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz";
+    hash = "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==";
+  };
+  "format" = {
+    out_path = "format";
+    name = "format@0.2.2";
+    url = "https://registry.npmjs.org/format/-/format-0.2.2.tgz";
+    hash = "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==";
+  };
+  "framer-motion" = {
+    out_path = "framer-motion";
+    name = "framer-motion@12.18.1";
+    url = "https://registry.npmjs.org/framer-motion/-/framer-motion-12.18.1.tgz";
+    hash = "sha512-6o4EDuRPLk4LSZ1kRnnEOurbQ86MklVk+Y1rFBUKiF+d2pCdvMjWVu0ZkyMVCTwl5UyTH2n/zJEJx+jvTYuxow==";
+  };
+  "fsevents" = {
+    out_path = "fsevents";
+    name = "fsevents@2.3.3";
+    url = "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz";
+    hash = "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==";
+  };
+  "gensync" = {
+    out_path = "gensync";
+    name = "gensync@1.0.0-beta.2";
+    url = "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz";
+    hash = "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==";
+  };
+  "get-nonce" = {
+    out_path = "get-nonce";
+    name = "get-nonce@1.0.1";
+    url = "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz";
+    hash = "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==";
+  };
+  "github-slugger" = {
+    out_path = "github-slugger";
+    name = "github-slugger@2.0.0";
+    url = "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz";
+    hash = "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==";
+  };
+  "globals" = {
+    out_path = "globals";
+    name = "globals@11.12.0";
+    url = "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz";
+    hash = "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==";
+  };
+  "graceful-fs" = {
+    out_path = "graceful-fs";
+    name = "graceful-fs@4.2.11";
+    url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz";
+    hash = "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==";
+  };
+  "hast-util-from-html" = {
+    out_path = "hast-util-from-html";
+    name = "hast-util-from-html@2.0.3";
+    url = "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz";
+    hash = "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==";
+  };
+  "hast-util-from-parse5" = {
+    out_path = "hast-util-from-parse5";
+    name = "hast-util-from-parse5@8.0.3";
+    url = "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz";
+    hash = "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==";
+  };
+  "hast-util-from-parse5/hastscript" = {
+    out_path = "hast-util-from-parse5/node_modules/hastscript";
+    name = "hastscript@9.0.1";
+    url = "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz";
+    hash = "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==";
+  };
+  "hast-util-from-parse5/hastscript/hast-util-parse-selector" = {
+    out_path = "hast-util-from-parse5/node_modules/hastscript/node_modules/hast-util-parse-selector";
+    name = "hast-util-parse-selector@4.0.0";
+    url = "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz";
+    hash = "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==";
+  };
+  "hast-util-has-property" = {
+    out_path = "hast-util-has-property";
+    name = "hast-util-has-property@3.0.0";
+    url = "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz";
+    hash = "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==";
+  };
+  "hast-util-heading-rank" = {
+    out_path = "hast-util-heading-rank";
+    name = "hast-util-heading-rank@3.0.0";
+    url = "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz";
+    hash = "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==";
+  };
+  "hast-util-is-element" = {
+    out_path = "hast-util-is-element";
+    name = "hast-util-is-element@3.0.0";
+    url = "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz";
+    hash = "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==";
+  };
+  "hast-util-parse-selector" = {
+    out_path = "hast-util-parse-selector";
+    name = "hast-util-parse-selector@2.2.5";
+    url = "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz";
+    hash = "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==";
+  };
+  "hast-util-raw" = {
+    out_path = "hast-util-raw";
+    name = "hast-util-raw@9.1.0";
+    url = "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz";
+    hash = "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==";
+  };
+  "hast-util-select" = {
+    out_path = "hast-util-select";
+    name = "hast-util-select@6.0.4";
+    url = "https://registry.npmjs.org/hast-util-select/-/hast-util-select-6.0.4.tgz";
+    hash = "sha512-RqGS1ZgI0MwxLaKLDxjprynNzINEkRHY2i8ln4DDjgv9ZhcYVIHN9rlpiYsqtFwrgpYU361SyWDQcGNIBVu3lw==";
+  };
+  "hast-util-to-html" = {
+    out_path = "hast-util-to-html";
+    name = "hast-util-to-html@9.0.5";
+    url = "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz";
+    hash = "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==";
+  };
+  "hast-util-to-jsx-runtime" = {
+    out_path = "hast-util-to-jsx-runtime";
+    name = "hast-util-to-jsx-runtime@2.3.6";
+    url = "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz";
+    hash = "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==";
+  };
+  "hast-util-to-parse5" = {
+    out_path = "hast-util-to-parse5";
+    name = "hast-util-to-parse5@8.0.0";
+    url = "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.0.tgz";
+    hash = "sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw==";
+  };
+  "hast-util-to-parse5/property-information" = {
+    out_path = "hast-util-to-parse5/node_modules/property-information";
+    name = "property-information@6.5.0";
+    url = "https://registry.npmjs.org/property-information/-/property-information-6.5.0.tgz";
+    hash = "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==";
+  };
+  "hast-util-to-string" = {
+    out_path = "hast-util-to-string";
+    name = "hast-util-to-string@3.0.1";
+    url = "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz";
+    hash = "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==";
+  };
+  "hast-util-whitespace" = {
+    out_path = "hast-util-whitespace";
+    name = "hast-util-whitespace@3.0.0";
+    url = "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz";
+    hash = "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==";
+  };
+  "hastscript" = {
+    out_path = "hastscript";
+    name = "hastscript@6.0.0";
+    url = "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz";
+    hash = "sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==";
+  };
+  "hastscript/@types/hast" = {
+    out_path = "hastscript/@types/node_modules/hast";
+    name = "@types/hast@2.3.10";
+    url = "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz";
+    hash = "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==";
+  };
+  "hastscript/@types/hast/@types/unist" = {
+    out_path = "hastscript/@types/node_modules/hast/node_modules/@types/node_modules/unist";
+    name = "@types/unist@2.0.11";
+    url = "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz";
+    hash = "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==";
+  };
+  "hastscript/comma-separated-tokens" = {
+    out_path = "hastscript/node_modules/comma-separated-tokens";
+    name = "comma-separated-tokens@1.0.8";
+    url = "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz";
+    hash = "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==";
+  };
+  "hastscript/property-information" = {
+    out_path = "hastscript/node_modules/property-information";
+    name = "property-information@5.6.0";
+    url = "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz";
+    hash = "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==";
+  };
+  "hastscript/space-separated-tokens" = {
+    out_path = "hastscript/node_modules/space-separated-tokens";
+    name = "space-separated-tokens@1.1.5";
+    url = "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz";
+    hash = "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==";
+  };
+  "highlight.js" = {
+    out_path = "highlight.js";
+    name = "highlight.js@10.7.3";
+    url = "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz";
+    hash = "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==";
+  };
+  "highlightjs-vue" = {
+    out_path = "highlightjs-vue";
+    name = "highlightjs-vue@1.0.0";
+    url = "https://registry.npmjs.org/highlightjs-vue/-/highlightjs-vue-1.0.0.tgz";
+    hash = "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==";
+  };
+  "html-url-attributes" = {
+    out_path = "html-url-attributes";
+    name = "html-url-attributes@3.0.1";
+    url = "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz";
+    hash = "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==";
+  };
+  "html-void-elements" = {
+    out_path = "html-void-elements";
+    name = "html-void-elements@3.0.0";
+    url = "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz";
+    hash = "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==";
+  };
+  "html2canvas" = {
+    out_path = "html2canvas";
+    name = "html2canvas@1.4.1";
+    url = "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz";
+    hash = "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==";
+  };
+  "inline-style-parser" = {
+    out_path = "inline-style-parser";
+    name = "inline-style-parser@0.2.4";
+    url = "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz";
+    hash = "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==";
+  };
+  "internmap" = {
+    out_path = "internmap";
+    name = "internmap@2.0.3";
+    url = "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz";
+    hash = "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==";
+  };
+  "is-alphabetical" = {
+    out_path = "is-alphabetical";
+    name = "is-alphabetical@1.0.4";
+    url = "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz";
+    hash = "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==";
+  };
+  "is-alphanumerical" = {
+    out_path = "is-alphanumerical";
+    name = "is-alphanumerical@1.0.4";
+    url = "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz";
+    hash = "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==";
+  };
+  "is-arrayish" = {
+    out_path = "is-arrayish";
+    name = "is-arrayish@0.3.2";
+    url = "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz";
+    hash = "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==";
+  };
+  "is-decimal" = {
+    out_path = "is-decimal";
+    name = "is-decimal@1.0.4";
+    url = "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz";
+    hash = "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==";
+  };
+  "is-extglob" = {
+    out_path = "is-extglob";
+    name = "is-extglob@2.1.1";
+    url = "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz";
+    hash = "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==";
+  };
+  "is-glob" = {
+    out_path = "is-glob";
+    name = "is-glob@4.0.3";
+    url = "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz";
+    hash = "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==";
+  };
+  "is-hexadecimal" = {
+    out_path = "is-hexadecimal";
+    name = "is-hexadecimal@1.0.4";
+    url = "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz";
+    hash = "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==";
+  };
+  "is-number" = {
+    out_path = "is-number";
+    name = "is-number@7.0.0";
+    url = "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz";
+    hash = "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==";
+  };
+  "is-plain-obj" = {
+    out_path = "is-plain-obj";
+    name = "is-plain-obj@4.1.0";
+    url = "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz";
+    hash = "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==";
+  };
+  "jiti" = {
+    out_path = "jiti";
+    binaries = {
+      "jiti" = "../jiti/lib/jiti-cli.mjs";
+    };
+    name = "jiti@2.4.2";
+    url = "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz";
+    hash = "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==";
+  };
+  "js-tokens" = {
+    out_path = "js-tokens";
+    name = "js-tokens@4.0.0";
+    url = "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz";
+    hash = "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==";
+  };
+  "jsesc" = {
+    out_path = "jsesc";
+    binaries = {
+      "jsesc" = "../jsesc/bin/jsesc";
+    };
+    name = "jsesc@3.1.0";
+    url = "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz";
+    hash = "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==";
+  };
+  "json5" = {
+    out_path = "json5";
+    binaries = {
+      "json5" = "../json5/lib/cli.js";
+    };
+    name = "json5@2.2.3";
+    url = "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz";
+    hash = "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==";
+  };
+  "lightningcss" = {
+    out_path = "lightningcss";
+    name = "lightningcss@1.30.1";
+    url = "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz";
+    hash = "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==";
+  };
+  "lightningcss-darwin-arm64" = {
+    out_path = "lightningcss-darwin-arm64";
+    name = "lightningcss-darwin-arm64@1.30.1";
+    url = "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.1.tgz";
+    hash = "sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==";
+  };
+  "lightningcss-darwin-x64" = {
+    out_path = "lightningcss-darwin-x64";
+    name = "lightningcss-darwin-x64@1.30.1";
+    url = "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.1.tgz";
+    hash = "sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==";
+  };
+  "lightningcss-freebsd-x64" = {
+    out_path = "lightningcss-freebsd-x64";
+    name = "lightningcss-freebsd-x64@1.30.1";
+    url = "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.1.tgz";
+    hash = "sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==";
+  };
+  "lightningcss-linux-arm-gnueabihf" = {
+    out_path = "lightningcss-linux-arm-gnueabihf";
+    name = "lightningcss-linux-arm-gnueabihf@1.30.1";
+    url = "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.1.tgz";
+    hash = "sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==";
+  };
+  "lightningcss-linux-arm64-gnu" = {
+    out_path = "lightningcss-linux-arm64-gnu";
+    name = "lightningcss-linux-arm64-gnu@1.30.1";
+    url = "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.1.tgz";
+    hash = "sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==";
+  };
+  "lightningcss-linux-arm64-musl" = {
+    out_path = "lightningcss-linux-arm64-musl";
+    name = "lightningcss-linux-arm64-musl@1.30.1";
+    url = "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.1.tgz";
+    hash = "sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==";
+  };
+  "lightningcss-linux-x64-gnu" = {
+    out_path = "lightningcss-linux-x64-gnu";
+    name = "lightningcss-linux-x64-gnu@1.30.1";
+    url = "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz";
+    hash = "sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==";
+  };
+  "lightningcss-linux-x64-musl" = {
+    out_path = "lightningcss-linux-x64-musl";
+    name = "lightningcss-linux-x64-musl@1.30.1";
+    url = "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.1.tgz";
+    hash = "sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==";
+  };
+  "lightningcss-win32-arm64-msvc" = {
+    out_path = "lightningcss-win32-arm64-msvc";
+    name = "lightningcss-win32-arm64-msvc@1.30.1";
+    url = "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.1.tgz";
+    hash = "sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==";
+  };
+  "lightningcss-win32-x64-msvc" = {
+    out_path = "lightningcss-win32-x64-msvc";
+    name = "lightningcss-win32-x64-msvc@1.30.1";
+    url = "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.1.tgz";
+    hash = "sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==";
+  };
+  "lodash" = {
+    out_path = "lodash";
+    name = "lodash@4.17.21";
+    url = "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz";
+    hash = "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==";
+  };
+  "longest-streak" = {
+    out_path = "longest-streak";
+    name = "longest-streak@3.1.0";
+    url = "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz";
+    hash = "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==";
+  };
+  "loose-envify" = {
+    out_path = "loose-envify";
+    binaries = {
+      "loose-envify" = "../loose-envify/cli.js";
+    };
+    name = "loose-envify@1.4.0";
+    url = "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz";
+    hash = "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==";
+  };
+  "lowlight" = {
+    out_path = "lowlight";
+    name = "lowlight@1.20.0";
+    url = "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz";
+    hash = "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==";
+  };
+  "lru-cache" = {
+    out_path = "lru-cache";
+    name = "lru-cache@5.1.1";
+    url = "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz";
+    hash = "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==";
+  };
+  "lru-cache/yallist" = {
+    out_path = "lru-cache/node_modules/yallist";
+    name = "yallist@3.1.1";
+    url = "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz";
+    hash = "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==";
+  };
+  "lucide-react" = {
+    out_path = "lucide-react";
+    name = "lucide-react@0.468.0";
+    url = "https://registry.npmjs.org/lucide-react/-/lucide-react-0.468.0.tgz";
+    hash = "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA==";
+  };
+  "magic-string" = {
+    out_path = "magic-string";
+    name = "magic-string@0.30.17";
+    url = "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz";
+    hash = "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==";
+  };
+  "markdown-table" = {
+    out_path = "markdown-table";
+    name = "markdown-table@3.0.4";
+    url = "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz";
+    hash = "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==";
+  };
+  "mdast-util-find-and-replace" = {
+    out_path = "mdast-util-find-and-replace";
+    name = "mdast-util-find-and-replace@3.0.2";
+    url = "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz";
+    hash = "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==";
+  };
+  "mdast-util-from-markdown" = {
+    out_path = "mdast-util-from-markdown";
+    name = "mdast-util-from-markdown@2.0.2";
+    url = "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz";
+    hash = "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==";
+  };
+  "mdast-util-gfm" = {
+    out_path = "mdast-util-gfm";
+    name = "mdast-util-gfm@3.1.0";
+    url = "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz";
+    hash = "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==";
+  };
+  "mdast-util-gfm-autolink-literal" = {
+    out_path = "mdast-util-gfm-autolink-literal";
+    name = "mdast-util-gfm-autolink-literal@2.0.1";
+    url = "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz";
+    hash = "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==";
+  };
+  "mdast-util-gfm-footnote" = {
+    out_path = "mdast-util-gfm-footnote";
+    name = "mdast-util-gfm-footnote@2.1.0";
+    url = "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz";
+    hash = "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==";
+  };
+  "mdast-util-gfm-strikethrough" = {
+    out_path = "mdast-util-gfm-strikethrough";
+    name = "mdast-util-gfm-strikethrough@2.0.0";
+    url = "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz";
+    hash = "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==";
+  };
+  "mdast-util-gfm-table" = {
+    out_path = "mdast-util-gfm-table";
+    name = "mdast-util-gfm-table@2.0.0";
+    url = "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz";
+    hash = "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==";
+  };
+  "mdast-util-gfm-task-list-item" = {
+    out_path = "mdast-util-gfm-task-list-item";
+    name = "mdast-util-gfm-task-list-item@2.0.0";
+    url = "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz";
+    hash = "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==";
+  };
+  "mdast-util-mdx-expression" = {
+    out_path = "mdast-util-mdx-expression";
+    name = "mdast-util-mdx-expression@2.0.1";
+    url = "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz";
+    hash = "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==";
+  };
+  "mdast-util-mdx-jsx" = {
+    out_path = "mdast-util-mdx-jsx";
+    name = "mdast-util-mdx-jsx@3.2.0";
+    url = "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz";
+    hash = "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==";
+  };
+  "mdast-util-mdx-jsx/parse-entities" = {
+    out_path = "mdast-util-mdx-jsx/node_modules/parse-entities";
+    name = "parse-entities@4.0.2";
+    url = "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz";
+    hash = "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==";
+  };
+  "mdast-util-mdx-jsx/parse-entities/@types/unist" = {
+    out_path = "mdast-util-mdx-jsx/parse-entities/node_modules/@types/node_modules/unist";
+    name = "@types/unist@2.0.11";
+    url = "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz";
+    hash = "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==";
+  };
+  "mdast-util-mdx-jsx/parse-entities/character-entities-legacy" = {
+    out_path = "mdast-util-mdx-jsx/node_modules/parse-entities/node_modules/character-entities-legacy";
+    name = "character-entities-legacy@3.0.0";
+    url = "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz";
+    hash = "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==";
+  };
+  "mdast-util-mdx-jsx/parse-entities/character-reference-invalid" = {
+    out_path = "mdast-util-mdx-jsx/node_modules/parse-entities/node_modules/character-reference-invalid";
+    name = "character-reference-invalid@2.0.1";
+    url = "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz";
+    hash = "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==";
+  };
+  "mdast-util-mdx-jsx/parse-entities/is-alphanumerical" = {
+    out_path = "mdast-util-mdx-jsx/node_modules/parse-entities/node_modules/is-alphanumerical";
+    name = "is-alphanumerical@2.0.1";
+    url = "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz";
+    hash = "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==";
+  };
+  "mdast-util-mdx-jsx/parse-entities/is-alphanumerical/is-alphabetical" = {
+    out_path = "mdast-util-mdx-jsx/node_modules/parse-entities/node_modules/is-alphanumerical/node_modules/is-alphabetical";
+    name = "is-alphabetical@2.0.1";
+    url = "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz";
+    hash = "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==";
+  };
+  "mdast-util-mdx-jsx/parse-entities/is-decimal" = {
+    out_path = "mdast-util-mdx-jsx/node_modules/parse-entities/node_modules/is-decimal";
+    name = "is-decimal@2.0.1";
+    url = "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz";
+    hash = "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==";
+  };
+  "mdast-util-mdx-jsx/parse-entities/is-hexadecimal" = {
+    out_path = "mdast-util-mdx-jsx/node_modules/parse-entities/node_modules/is-hexadecimal";
+    name = "is-hexadecimal@2.0.1";
+    url = "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz";
+    hash = "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==";
+  };
+  "mdast-util-mdxjs-esm" = {
+    out_path = "mdast-util-mdxjs-esm";
+    name = "mdast-util-mdxjs-esm@2.0.1";
+    url = "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz";
+    hash = "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==";
+  };
+  "mdast-util-phrasing" = {
+    out_path = "mdast-util-phrasing";
+    name = "mdast-util-phrasing@4.1.0";
+    url = "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz";
+    hash = "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==";
+  };
+  "mdast-util-to-hast" = {
+    out_path = "mdast-util-to-hast";
+    name = "mdast-util-to-hast@13.2.0";
+    url = "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz";
+    hash = "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==";
+  };
+  "mdast-util-to-markdown" = {
+    out_path = "mdast-util-to-markdown";
+    name = "mdast-util-to-markdown@2.1.2";
+    url = "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz";
+    hash = "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==";
+  };
+  "mdast-util-to-string" = {
+    out_path = "mdast-util-to-string";
+    name = "mdast-util-to-string@4.0.0";
+    url = "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz";
+    hash = "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==";
+  };
+  "micromark" = {
+    out_path = "micromark";
+    name = "micromark@4.0.2";
+    url = "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz";
+    hash = "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==";
+  };
+  "micromark-core-commonmark" = {
+    out_path = "micromark-core-commonmark";
+    name = "micromark-core-commonmark@2.0.3";
+    url = "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz";
+    hash = "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==";
+  };
+  "micromark-extension-gfm" = {
+    out_path = "micromark-extension-gfm";
+    name = "micromark-extension-gfm@3.0.0";
+    url = "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz";
+    hash = "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==";
+  };
+  "micromark-extension-gfm-autolink-literal" = {
+    out_path = "micromark-extension-gfm-autolink-literal";
+    name = "micromark-extension-gfm-autolink-literal@2.1.0";
+    url = "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz";
+    hash = "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==";
+  };
+  "micromark-extension-gfm-footnote" = {
+    out_path = "micromark-extension-gfm-footnote";
+    name = "micromark-extension-gfm-footnote@2.1.0";
+    url = "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz";
+    hash = "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==";
+  };
+  "micromark-extension-gfm-strikethrough" = {
+    out_path = "micromark-extension-gfm-strikethrough";
+    name = "micromark-extension-gfm-strikethrough@2.1.0";
+    url = "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz";
+    hash = "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==";
+  };
+  "micromark-extension-gfm-table" = {
+    out_path = "micromark-extension-gfm-table";
+    name = "micromark-extension-gfm-table@2.1.1";
+    url = "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz";
+    hash = "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==";
+  };
+  "micromark-extension-gfm-tagfilter" = {
+    out_path = "micromark-extension-gfm-tagfilter";
+    name = "micromark-extension-gfm-tagfilter@2.0.0";
+    url = "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz";
+    hash = "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==";
+  };
+  "micromark-extension-gfm-task-list-item" = {
+    out_path = "micromark-extension-gfm-task-list-item";
+    name = "micromark-extension-gfm-task-list-item@2.1.0";
+    url = "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz";
+    hash = "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==";
+  };
+  "micromark-factory-destination" = {
+    out_path = "micromark-factory-destination";
+    name = "micromark-factory-destination@2.0.1";
+    url = "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz";
+    hash = "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==";
+  };
+  "micromark-factory-label" = {
+    out_path = "micromark-factory-label";
+    name = "micromark-factory-label@2.0.1";
+    url = "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz";
+    hash = "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==";
+  };
+  "micromark-factory-space" = {
+    out_path = "micromark-factory-space";
+    name = "micromark-factory-space@2.0.1";
+    url = "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz";
+    hash = "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==";
+  };
+  "micromark-factory-title" = {
+    out_path = "micromark-factory-title";
+    name = "micromark-factory-title@2.0.1";
+    url = "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz";
+    hash = "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==";
+  };
+  "micromark-factory-whitespace" = {
+    out_path = "micromark-factory-whitespace";
+    name = "micromark-factory-whitespace@2.0.1";
+    url = "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz";
+    hash = "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==";
+  };
+  "micromark-util-character" = {
+    out_path = "micromark-util-character";
+    name = "micromark-util-character@2.1.1";
+    url = "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz";
+    hash = "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==";
+  };
+  "micromark-util-chunked" = {
+    out_path = "micromark-util-chunked";
+    name = "micromark-util-chunked@2.0.1";
+    url = "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz";
+    hash = "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==";
+  };
+  "micromark-util-classify-character" = {
+    out_path = "micromark-util-classify-character";
+    name = "micromark-util-classify-character@2.0.1";
+    url = "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz";
+    hash = "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==";
+  };
+  "micromark-util-combine-extensions" = {
+    out_path = "micromark-util-combine-extensions";
+    name = "micromark-util-combine-extensions@2.0.1";
+    url = "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz";
+    hash = "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==";
+  };
+  "micromark-util-decode-numeric-character-reference" = {
+    out_path = "micromark-util-decode-numeric-character-reference";
+    name = "micromark-util-decode-numeric-character-reference@2.0.2";
+    url = "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz";
+    hash = "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==";
+  };
+  "micromark-util-decode-string" = {
+    out_path = "micromark-util-decode-string";
+    name = "micromark-util-decode-string@2.0.1";
+    url = "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz";
+    hash = "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==";
+  };
+  "micromark-util-encode" = {
+    out_path = "micromark-util-encode";
+    name = "micromark-util-encode@2.0.1";
+    url = "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz";
+    hash = "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==";
+  };
+  "micromark-util-html-tag-name" = {
+    out_path = "micromark-util-html-tag-name";
+    name = "micromark-util-html-tag-name@2.0.1";
+    url = "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz";
+    hash = "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==";
+  };
+  "micromark-util-normalize-identifier" = {
+    out_path = "micromark-util-normalize-identifier";
+    name = "micromark-util-normalize-identifier@2.0.1";
+    url = "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz";
+    hash = "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==";
+  };
+  "micromark-util-resolve-all" = {
+    out_path = "micromark-util-resolve-all";
+    name = "micromark-util-resolve-all@2.0.1";
+    url = "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz";
+    hash = "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==";
+  };
+  "micromark-util-sanitize-uri" = {
+    out_path = "micromark-util-sanitize-uri";
+    name = "micromark-util-sanitize-uri@2.0.1";
+    url = "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz";
+    hash = "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==";
+  };
+  "micromark-util-subtokenize" = {
+    out_path = "micromark-util-subtokenize";
+    name = "micromark-util-subtokenize@2.1.0";
+    url = "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz";
+    hash = "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==";
+  };
+  "micromark-util-symbol" = {
+    out_path = "micromark-util-symbol";
+    name = "micromark-util-symbol@2.0.1";
+    url = "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz";
+    hash = "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==";
+  };
+  "micromark-util-types" = {
+    out_path = "micromark-util-types";
+    name = "micromark-util-types@2.0.2";
+    url = "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz";
+    hash = "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==";
+  };
+  "micromatch" = {
+    out_path = "micromatch";
+    name = "micromatch@4.0.8";
+    url = "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz";
+    hash = "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==";
+  };
+  "micromatch/picomatch" = {
+    out_path = "micromatch/node_modules/picomatch";
+    name = "picomatch@2.3.1";
+    url = "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz";
+    hash = "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==";
+  };
+  "minipass" = {
+    out_path = "minipass";
+    name = "minipass@7.1.2";
+    url = "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz";
+    hash = "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==";
+  };
+  "minizlib" = {
+    out_path = "minizlib";
+    name = "minizlib@3.0.2";
+    url = "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz";
+    hash = "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==";
+  };
+  "mkdirp" = {
+    out_path = "mkdirp";
+    binaries = {
+      "mkdirp" = "../mkdirp/dist/cjs/src/bin.js";
+    };
+    name = "mkdirp@3.0.1";
+    url = "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz";
+    hash = "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==";
+  };
+  "motion-dom" = {
+    out_path = "motion-dom";
+    name = "motion-dom@12.18.1";
+    url = "https://registry.npmjs.org/motion-dom/-/motion-dom-12.18.1.tgz";
+    hash = "sha512-dR/4EYT23Snd+eUSLrde63Ws3oXQtJNw/krgautvTfwrN/2cHfCZMdu6CeTxVfRRWREW3Fy1f5vobRDiBb/q+w==";
+  };
+  "motion-utils" = {
+    out_path = "motion-utils";
+    name = "motion-utils@12.18.1";
+    url = "https://registry.npmjs.org/motion-utils/-/motion-utils-12.18.1.tgz";
+    hash = "sha512-az26YDU4WoDP0ueAkUtABLk2BIxe28d8NH1qWT8jPGhPyf44XTdDUh8pDk9OPphaSrR9McgpcJlgwSOIw/sfkA==";
+  };
+  "mri" = {
+    out_path = "mri";
+    name = "mri@1.2.0";
+    url = "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz";
+    hash = "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==";
+  };
+  "ms" = {
+    out_path = "ms";
+    name = "ms@2.1.3";
+    url = "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz";
+    hash = "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==";
+  };
+  "nanoid" = {
+    out_path = "nanoid";
+    binaries = {
+      "nanoid" = "../nanoid/bin/nanoid.cjs";
+    };
+    name = "nanoid@3.3.11";
+    url = "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz";
+    hash = "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==";
+  };
+  "node-addon-api" = {
+    out_path = "node-addon-api";
+    name = "node-addon-api@7.1.1";
+    url = "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz";
+    hash = "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==";
+  };
+  "node-releases" = {
+    out_path = "node-releases";
+    name = "node-releases@2.0.19";
+    url = "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz";
+    hash = "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==";
+  };
+  "nth-check" = {
+    out_path = "nth-check";
+    name = "nth-check@2.1.1";
+    url = "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz";
+    hash = "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==";
+  };
+  "object-assign" = {
+    out_path = "object-assign";
+    name = "object-assign@4.1.1";
+    url = "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz";
+    hash = "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==";
+  };
+  "parse-entities" = {
+    out_path = "parse-entities";
+    name = "parse-entities@2.0.0";
+    url = "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz";
+    hash = "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==";
+  };
+  "parse-numeric-range" = {
+    out_path = "parse-numeric-range";
+    name = "parse-numeric-range@1.3.0";
+    url = "https://registry.npmjs.org/parse-numeric-range/-/parse-numeric-range-1.3.0.tgz";
+    hash = "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==";
+  };
+  "parse5" = {
+    out_path = "parse5";
+    name = "parse5@7.3.0";
+    url = "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz";
+    hash = "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==";
+  };
+  "parse5/entities" = {
+    out_path = "parse5/node_modules/entities";
+    name = "entities@6.0.1";
+    url = "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz";
+    hash = "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==";
+  };
+  "picocolors" = {
+    out_path = "picocolors";
+    name = "picocolors@1.1.1";
+    url = "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz";
+    hash = "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==";
+  };
+  "picomatch" = {
+    out_path = "picomatch";
+    name = "picomatch@4.0.2";
+    url = "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz";
+    hash = "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==";
+  };
+  "postcss" = {
+    out_path = "postcss";
+    name = "postcss@8.5.6";
+    url = "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz";
+    hash = "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==";
+  };
+  "prismjs" = {
+    out_path = "prismjs";
+    name = "prismjs@1.30.0";
+    url = "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz";
+    hash = "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==";
+  };
+  "prop-types" = {
+    out_path = "prop-types";
+    name = "prop-types@15.8.1";
+    url = "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz";
+    hash = "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==";
+  };
+  "prop-types/react-is" = {
+    out_path = "prop-types/node_modules/react-is";
+    name = "react-is@16.13.1";
+    url = "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz";
+    hash = "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==";
+  };
+  "property-information" = {
+    out_path = "property-information";
+    name = "property-information@7.1.0";
+    url = "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz";
+    hash = "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==";
+  };
+  "react" = {
+    out_path = "react";
+    name = "react@18.3.1";
+    url = "https://registry.npmjs.org/react/-/react-18.3.1.tgz";
+    hash = "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==";
+  };
+  "react-dom" = {
+    out_path = "react-dom";
+    name = "react-dom@18.3.1";
+    url = "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz";
+    hash = "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==";
+  };
+  "react-hook-form" = {
+    out_path = "react-hook-form";
+    name = "react-hook-form@7.58.1";
+    url = "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.58.1.tgz";
+    hash = "sha512-Lml/KZYEEFfPhUVgE0RdCVpnC4yhW+PndRhbiTtdvSlQTL8IfVR+iQkBjLIvmmc6+GGoVeM11z37ktKFPAb0FA==";
+  };
+  "react-is" = {
+    out_path = "react-is";
+    name = "react-is@18.3.1";
+    url = "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz";
+    hash = "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==";
+  };
+  "react-markdown" = {
+    out_path = "react-markdown";
+    name = "react-markdown@9.1.0";
+    url = "https://registry.npmjs.org/react-markdown/-/react-markdown-9.1.0.tgz";
+    hash = "sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==";
+  };
+  "react-refresh" = {
+    out_path = "react-refresh";
+    name = "react-refresh@0.17.0";
+    url = "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz";
+    hash = "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==";
+  };
+  "react-remove-scroll" = {
+    out_path = "react-remove-scroll";
+    name = "react-remove-scroll@2.7.1";
+    url = "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz";
+    hash = "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==";
+  };
+  "react-remove-scroll-bar" = {
+    out_path = "react-remove-scroll-bar";
+    name = "react-remove-scroll-bar@2.3.8";
+    url = "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz";
+    hash = "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==";
+  };
+  "react-smooth" = {
+    out_path = "react-smooth";
+    name = "react-smooth@4.0.4";
+    url = "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz";
+    hash = "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==";
+  };
+  "react-style-singleton" = {
+    out_path = "react-style-singleton";
+    name = "react-style-singleton@2.2.3";
+    url = "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz";
+    hash = "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==";
+  };
+  "react-syntax-highlighter" = {
+    out_path = "react-syntax-highlighter";
+    name = "react-syntax-highlighter@15.6.1";
+    url = "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.6.1.tgz";
+    hash = "sha512-OqJ2/vL7lEeV5zTJyG7kmARppUjiB9h9udl4qHQjjgEos66z00Ia0OckwYfRxCSFrW8RJIBnsBwQsHZbVPspqg==";
+  };
+  "react-transition-group" = {
+    out_path = "react-transition-group";
+    name = "react-transition-group@4.4.5";
+    url = "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz";
+    hash = "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==";
+  };
+  "recharts" = {
+    out_path = "recharts";
+    name = "recharts@2.15.3";
+    url = "https://registry.npmjs.org/recharts/-/recharts-2.15.3.tgz";
+    hash = "sha512-EdOPzTwcFSuqtvkDoaM5ws/Km1+WTAO2eizL7rqiG0V2UVhTnz0m7J2i0CjVPUCdEkZImaWvXLbZDS2H5t6GFQ==";
+  };
+  "recharts-scale" = {
+    out_path = "recharts-scale";
+    name = "recharts-scale@0.4.5";
+    url = "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz";
+    hash = "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==";
+  };
+  "refractor" = {
+    out_path = "refractor";
+    name = "refractor@3.6.0";
+    url = "https://registry.npmjs.org/refractor/-/refractor-3.6.0.tgz";
+    hash = "sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==";
+  };
+  "refractor/prismjs" = {
+    out_path = "refractor/node_modules/prismjs";
+    name = "prismjs@1.27.0";
+    url = "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz";
+    hash = "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==";
+  };
+  "rehype" = {
+    out_path = "rehype";
+    name = "rehype@13.0.2";
+    url = "https://registry.npmjs.org/rehype/-/rehype-13.0.2.tgz";
+    hash = "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==";
+  };
+  "rehype-attr" = {
+    out_path = "rehype-attr";
+    name = "rehype-attr@3.0.3";
+    url = "https://registry.npmjs.org/rehype-attr/-/rehype-attr-3.0.3.tgz";
+    hash = "sha512-Up50Xfra8tyxnkJdCzLBIBtxOcB2M1xdeKe1324U06RAvSjYm7ULSeoM+b/nYPQPVd7jsXJ9+39IG1WAJPXONw==";
+  };
+  "rehype-autolink-headings" = {
+    out_path = "rehype-autolink-headings";
+    name = "rehype-autolink-headings@7.1.0";
+    url = "https://registry.npmjs.org/rehype-autolink-headings/-/rehype-autolink-headings-7.1.0.tgz";
+    hash = "sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw==";
+  };
+  "rehype-ignore" = {
+    out_path = "rehype-ignore";
+    name = "rehype-ignore@2.0.2";
+    url = "https://registry.npmjs.org/rehype-ignore/-/rehype-ignore-2.0.2.tgz";
+    hash = "sha512-BpAT/3lU9DMJ2siYVD/dSR0A/zQgD6Fb+fxkJd4j+wDVy6TYbYpK+FZqu8eM9EuNKGvi4BJR7XTZ/+zF02Dq8w==";
+  };
+  "rehype-parse" = {
+    out_path = "rehype-parse";
+    name = "rehype-parse@9.0.1";
+    url = "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz";
+    hash = "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==";
+  };
+  "rehype-prism-plus" = {
+    out_path = "rehype-prism-plus";
+    name = "rehype-prism-plus@2.0.1";
+    url = "https://registry.npmjs.org/rehype-prism-plus/-/rehype-prism-plus-2.0.1.tgz";
+    hash = "sha512-Wglct0OW12tksTUseAPyWPo3srjBOY7xKlql/DPKi7HbsdZTyaLCAoO58QBKSczFQxElTsQlOY3JDOFzB/K++Q==";
+  };
+  "rehype-prism-plus/refractor" = {
+    out_path = "rehype-prism-plus/node_modules/refractor";
+    name = "refractor@4.9.0";
+    url = "https://registry.npmjs.org/refractor/-/refractor-4.9.0.tgz";
+    hash = "sha512-nEG1SPXFoGGx+dcjftjv8cAjEusIh6ED1xhf5DG3C0x/k+rmZ2duKnc3QLpt6qeHv5fPb8uwN3VWN2BT7fr3Og==";
+  };
+  "rehype-prism-plus/refractor/@types/hast" = {
+    out_path = "rehype-prism-plus/refractor/node_modules/@types/node_modules/hast";
+    name = "@types/hast@2.3.10";
+    url = "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz";
+    hash = "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==";
+  };
+  "rehype-prism-plus/refractor/@types/hast/@types/unist" = {
+    out_path = "rehype-prism-plus/refractor/node_modules/@types/node_modules/hast/node_modules/@types/node_modules/unist";
+    name = "@types/unist@2.0.11";
+    url = "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz";
+    hash = "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==";
+  };
+  "rehype-prism-plus/refractor/hastscript" = {
+    out_path = "rehype-prism-plus/node_modules/refractor/node_modules/hastscript";
+    name = "hastscript@7.2.0";
+    url = "https://registry.npmjs.org/hastscript/-/hastscript-7.2.0.tgz";
+    hash = "sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==";
+  };
+  "rehype-prism-plus/refractor/hastscript/hast-util-parse-selector" = {
+    out_path = "rehype-prism-plus/node_modules/refractor/node_modules/hastscript/node_modules/hast-util-parse-selector";
+    name = "hast-util-parse-selector@3.1.1";
+    url = "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-3.1.1.tgz";
+    hash = "sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==";
+  };
+  "rehype-prism-plus/refractor/hastscript/property-information" = {
+    out_path = "rehype-prism-plus/node_modules/refractor/node_modules/hastscript/node_modules/property-information";
+    name = "property-information@6.5.0";
+    url = "https://registry.npmjs.org/property-information/-/property-information-6.5.0.tgz";
+    hash = "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==";
+  };
+  "rehype-prism-plus/refractor/parse-entities" = {
+    out_path = "rehype-prism-plus/node_modules/refractor/node_modules/parse-entities";
+    name = "parse-entities@4.0.2";
+    url = "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz";
+    hash = "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==";
+  };
+  "rehype-prism-plus/refractor/parse-entities/@types/unist" = {
+    out_path = "rehype-prism-plus/refractor/node_modules/parse-entities/node_modules/@types/node_modules/unist";
+    name = "@types/unist@2.0.11";
+    url = "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz";
+    hash = "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==";
+  };
+  "rehype-prism-plus/refractor/parse-entities/character-entities-legacy" = {
+    out_path = "rehype-prism-plus/node_modules/refractor/node_modules/parse-entities/node_modules/character-entities-legacy";
+    name = "character-entities-legacy@3.0.0";
+    url = "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz";
+    hash = "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==";
+  };
+  "rehype-prism-plus/refractor/parse-entities/character-reference-invalid" = {
+    out_path = "rehype-prism-plus/node_modules/refractor/node_modules/parse-entities/node_modules/character-reference-invalid";
+    name = "character-reference-invalid@2.0.1";
+    url = "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz";
+    hash = "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==";
+  };
+  "rehype-prism-plus/refractor/parse-entities/is-alphanumerical" = {
+    out_path = "rehype-prism-plus/node_modules/refractor/node_modules/parse-entities/node_modules/is-alphanumerical";
+    name = "is-alphanumerical@2.0.1";
+    url = "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz";
+    hash = "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==";
+  };
+  "rehype-prism-plus/refractor/parse-entities/is-alphanumerical/is-alphabetical" = {
+    out_path = "rehype-prism-plus/node_modules/refractor/node_modules/parse-entities/node_modules/is-alphanumerical/node_modules/is-alphabetical";
+    name = "is-alphabetical@2.0.1";
+    url = "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz";
+    hash = "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==";
+  };
+  "rehype-prism-plus/refractor/parse-entities/is-decimal" = {
+    out_path = "rehype-prism-plus/node_modules/refractor/node_modules/parse-entities/node_modules/is-decimal";
+    name = "is-decimal@2.0.1";
+    url = "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz";
+    hash = "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==";
+  };
+  "rehype-prism-plus/refractor/parse-entities/is-hexadecimal" = {
+    out_path = "rehype-prism-plus/node_modules/refractor/node_modules/parse-entities/node_modules/is-hexadecimal";
+    name = "is-hexadecimal@2.0.1";
+    url = "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz";
+    hash = "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==";
+  };
+  "rehype-raw" = {
+    out_path = "rehype-raw";
+    name = "rehype-raw@7.0.0";
+    url = "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz";
+    hash = "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==";
+  };
+  "rehype-rewrite" = {
+    out_path = "rehype-rewrite";
+    name = "rehype-rewrite@4.0.2";
+    url = "https://registry.npmjs.org/rehype-rewrite/-/rehype-rewrite-4.0.2.tgz";
+    hash = "sha512-rjLJ3z6fIV11phwCqHp/KRo8xuUCO8o9bFJCNw5o6O2wlLk6g8r323aRswdGBQwfXPFYeSuZdAjp4tzo6RGqEg==";
+  };
+  "rehype-slug" = {
+    out_path = "rehype-slug";
+    name = "rehype-slug@6.0.0";
+    url = "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz";
+    hash = "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==";
+  };
+  "rehype-stringify" = {
+    out_path = "rehype-stringify";
+    name = "rehype-stringify@10.0.1";
+    url = "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz";
+    hash = "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==";
+  };
+  "remark-gfm" = {
+    out_path = "remark-gfm";
+    name = "remark-gfm@4.0.1";
+    url = "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz";
+    hash = "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==";
+  };
+  "remark-github-blockquote-alert" = {
+    out_path = "remark-github-blockquote-alert";
+    name = "remark-github-blockquote-alert@1.3.1";
+    url = "https://registry.npmjs.org/remark-github-blockquote-alert/-/remark-github-blockquote-alert-1.3.1.tgz";
+    hash = "sha512-OPNnimcKeozWN1w8KVQEuHOxgN3L4rah8geMOLhA5vN9wITqU4FWD+G26tkEsCGHiOVDbISx+Se5rGZ+D1p0Jg==";
+  };
+  "remark-parse" = {
+    out_path = "remark-parse";
+    name = "remark-parse@11.0.0";
+    url = "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz";
+    hash = "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==";
+  };
+  "remark-rehype" = {
+    out_path = "remark-rehype";
+    name = "remark-rehype@11.1.2";
+    url = "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz";
+    hash = "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==";
+  };
+  "remark-stringify" = {
+    out_path = "remark-stringify";
+    name = "remark-stringify@11.0.0";
+    url = "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz";
+    hash = "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==";
+  };
+  "rollup" = {
+    out_path = "rollup";
+    binaries = {
+      "rollup" = "../rollup/dist/bin/rollup";
+    };
+    name = "rollup@4.43.0";
+    url = "https://registry.npmjs.org/rollup/-/rollup-4.43.0.tgz";
+    hash = "sha512-wdN2Kd3Twh8MAEOEJZsuxuLKCsBEo4PVNLK6tQWAn10VhsVewQLzcucMgLolRlhFybGxfclbPeEYBaP6RvUFGg==";
+  };
+  "scheduler" = {
+    out_path = "scheduler";
+    name = "scheduler@0.23.2";
+    url = "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz";
+    hash = "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==";
+  };
+  "semver" = {
+    out_path = "semver";
+    binaries = {
+      "semver" = "../semver/bin/semver.js";
+    };
+    name = "semver@7.7.2";
+    url = "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz";
+    hash = "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==";
+  };
+  "sharp" = {
+    out_path = "sharp";
+    name = "sharp@0.34.2";
+    url = "https://registry.npmjs.org/sharp/-/sharp-0.34.2.tgz";
+    hash = "sha512-lszvBmB9QURERtyKT2bNmsgxXK0ShJrL/fvqlonCo7e6xBF8nT8xU6pW+PMIbLsz0RxQk3rgH9kd8UmvOzlMJg==";
+  };
+  "simple-swizzle" = {
+    out_path = "simple-swizzle";
+    name = "simple-swizzle@0.2.2";
+    url = "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz";
+    hash = "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==";
+  };
+  "source-map-js" = {
+    out_path = "source-map-js";
+    name = "source-map-js@1.2.1";
+    url = "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz";
+    hash = "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==";
+  };
+  "space-separated-tokens" = {
+    out_path = "space-separated-tokens";
+    name = "space-separated-tokens@2.0.2";
+    url = "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz";
+    hash = "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==";
+  };
+  "stringify-entities" = {
+    out_path = "stringify-entities";
+    name = "stringify-entities@4.0.4";
+    url = "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz";
+    hash = "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==";
+  };
+  "stringify-entities/character-entities-legacy" = {
+    out_path = "stringify-entities/node_modules/character-entities-legacy";
+    name = "character-entities-legacy@3.0.0";
+    url = "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz";
+    hash = "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==";
+  };
+  "style-to-js" = {
+    out_path = "style-to-js";
+    name = "style-to-js@1.1.17";
+    url = "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.17.tgz";
+    hash = "sha512-xQcBGDxJb6jjFCTzvQtfiPn6YvvP2O8U1MDIPNfJQlWMYfktPy+iGsHE7cssjs7y84d9fQaK4UF3RIJaAHSoYA==";
+  };
+  "style-to-object" = {
+    out_path = "style-to-object";
+    name = "style-to-object@1.0.9";
+    url = "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.9.tgz";
+    hash = "sha512-G4qppLgKu/k6FwRpHiGiKPaPTFcG3g4wNVX/Qsfu+RqQM30E7Tyu/TEgxcL9PNLF5pdRLwQdE3YKKf+KF2Dzlw==";
+  };
+  "tailwind-merge" = {
+    out_path = "tailwind-merge";
+    name = "tailwind-merge@2.6.0";
+    url = "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.0.tgz";
+    hash = "sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==";
+  };
+  "tailwindcss" = {
+    out_path = "tailwindcss";
+    name = "tailwindcss@4.1.10";
+    url = "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.10.tgz";
+    hash = "sha512-P3nr6WkvKV/ONsTzj6Gb57sWPMX29EPNPopo7+FcpkQaNsrNpZ1pv8QmrYI2RqEKD7mlGqLnGovlcYnBK0IqUA==";
+  };
+  "tapable" = {
+    out_path = "tapable";
+    name = "tapable@2.2.2";
+    url = "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz";
+    hash = "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==";
+  };
+  "tar" = {
+    out_path = "tar";
+    name = "tar@7.4.3";
+    url = "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz";
+    hash = "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==";
+  };
+  "text-segmentation" = {
+    out_path = "text-segmentation";
+    name = "text-segmentation@1.0.3";
+    url = "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz";
+    hash = "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==";
+  };
+  "tiny-invariant" = {
+    out_path = "tiny-invariant";
+    name = "tiny-invariant@1.3.3";
+    url = "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz";
+    hash = "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==";
+  };
+  "tinyglobby" = {
+    out_path = "tinyglobby";
+    name = "tinyglobby@0.2.14";
+    url = "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz";
+    hash = "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==";
+  };
+  "to-regex-range" = {
+    out_path = "to-regex-range";
+    name = "to-regex-range@5.0.1";
+    url = "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz";
+    hash = "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==";
+  };
+  "trim-lines" = {
+    out_path = "trim-lines";
+    name = "trim-lines@3.0.1";
+    url = "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz";
+    hash = "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==";
+  };
+  "trough" = {
+    out_path = "trough";
+    name = "trough@2.2.0";
+    url = "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz";
+    hash = "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==";
+  };
+  "tslib" = {
+    out_path = "tslib";
+    name = "tslib@2.8.1";
+    url = "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz";
+    hash = "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==";
+  };
+  "typescript" = {
+    out_path = "typescript";
+    binaries = {
+      "tsc" = "../typescript/bin/tsc";
+      "tsserver" = "../typescript/bin/tsserver";
+    };
+    name = "typescript@5.6.3";
+    url = "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz";
+    hash = "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==";
+  };
+  "undici-types" = {
+    out_path = "undici-types";
+    name = "undici-types@6.21.0";
+    url = "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz";
+    hash = "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==";
+  };
+  "unified" = {
+    out_path = "unified";
+    name = "unified@11.0.5";
+    url = "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz";
+    hash = "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==";
+  };
+  "unist-util-filter" = {
+    out_path = "unist-util-filter";
+    name = "unist-util-filter@5.0.1";
+    url = "https://registry.npmjs.org/unist-util-filter/-/unist-util-filter-5.0.1.tgz";
+    hash = "sha512-pHx7D4Zt6+TsfwylH9+lYhBhzyhEnCXs/lbq/Hstxno5z4gVdyc2WEW0asfjGKPyG4pEKrnBv5hdkO6+aRnQJw==";
+  };
+  "unist-util-is" = {
+    out_path = "unist-util-is";
+    name = "unist-util-is@6.0.0";
+    url = "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz";
+    hash = "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==";
+  };
+  "unist-util-position" = {
+    out_path = "unist-util-position";
+    name = "unist-util-position@5.0.0";
+    url = "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz";
+    hash = "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==";
+  };
+  "unist-util-stringify-position" = {
+    out_path = "unist-util-stringify-position";
+    name = "unist-util-stringify-position@4.0.0";
+    url = "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz";
+    hash = "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==";
+  };
+  "unist-util-visit" = {
+    out_path = "unist-util-visit";
+    name = "unist-util-visit@5.0.0";
+    url = "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz";
+    hash = "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==";
+  };
+  "unist-util-visit-parents" = {
+    out_path = "unist-util-visit-parents";
+    name = "unist-util-visit-parents@6.0.1";
+    url = "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz";
+    hash = "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==";
+  };
+  "update-browserslist-db" = {
+    out_path = "update-browserslist-db";
+    binaries = {
+      "update-browserslist-db" = "../update-browserslist-db/cli.js";
+    };
+    name = "update-browserslist-db@1.1.3";
+    url = "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz";
+    hash = "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==";
+  };
+  "use-callback-ref" = {
+    out_path = "use-callback-ref";
+    name = "use-callback-ref@1.3.3";
+    url = "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz";
+    hash = "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==";
+  };
+  "use-sidecar" = {
+    out_path = "use-sidecar";
+    name = "use-sidecar@1.1.3";
+    url = "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz";
+    hash = "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==";
+  };
+  "utrie" = {
+    out_path = "utrie";
+    name = "utrie@1.0.2";
+    url = "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz";
+    hash = "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==";
+  };
+  "vfile" = {
+    out_path = "vfile";
+    name = "vfile@6.0.3";
+    url = "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz";
+    hash = "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==";
+  };
+  "vfile-location" = {
+    out_path = "vfile-location";
+    name = "vfile-location@5.0.3";
+    url = "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz";
+    hash = "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==";
+  };
+  "vfile-message" = {
+    out_path = "vfile-message";
+    name = "vfile-message@4.0.2";
+    url = "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz";
+    hash = "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==";
+  };
+  "victory-vendor" = {
+    out_path = "victory-vendor";
+    name = "victory-vendor@36.9.2";
+    url = "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz";
+    hash = "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==";
+  };
+  "vite" = {
+    out_path = "vite";
+    binaries = {
+      "vite" = "../vite/bin/vite.js";
+    };
+    name = "vite@6.3.5";
+    url = "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz";
+    hash = "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==";
+  };
+  "web-namespaces" = {
+    out_path = "web-namespaces";
+    name = "web-namespaces@2.0.1";
+    url = "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz";
+    hash = "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==";
+  };
+  "xtend" = {
+    out_path = "xtend";
+    name = "xtend@4.0.2";
+    url = "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz";
+    hash = "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==";
+  };
+  "yallist" = {
+    out_path = "yallist";
+    name = "yallist@5.0.0";
+    url = "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz";
+    hash = "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==";
+  };
+  "zod" = {
+    out_path = "zod";
+    name = "zod@3.25.67";
+    url = "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz";
+    hash = "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==";
+  };
+  "zwitch" = {
+    out_path = "zwitch";
+    name = "zwitch@2.0.4";
+    url = "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz";
+    hash = "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==";
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,167 @@
+{
+  "nodes": {
+    "blueprint": {
+      "inputs": {
+        "nixpkgs": [
+          "bun2nix",
+          "nixpkgs"
+        ],
+        "systems": [
+          "bun2nix",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1744632722,
+        "narHash": "sha256-0chvqUV1Kzf8BMQ7MsH3CeicJEb2HeCpwliS77FGyfc=",
+        "owner": "numtide",
+        "repo": "blueprint",
+        "rev": "49bbd5d072b577072f4a1d07d4b0621ecce768af",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "blueprint",
+        "type": "github"
+      }
+    },
+    "bun2nix": {
+      "inputs": {
+        "blueprint": "blueprint",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1750682174,
+        "narHash": "sha256-rUpcATQ0LiY8IYRndqTlPUhF4YGJH3lM2aMOs5vBDGM=",
+        "owner": "baileyluTCD",
+        "repo": "bun2nix",
+        "rev": "85d692d68a5345d868d3bb1158b953d2996d70f7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "baileyluTCD",
+        "repo": "bun2nix",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1751011381,
+        "narHash": "sha256-krGXKxvkBhnrSC/kGBmg5MyupUUT5R6IBCLEzx9jhMM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "30e2e2857ba47844aa71991daa6ed1fc678bcbb7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "bun2nix": "bun2nix",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1751165203,
+        "narHash": "sha256-3QhlpAk2yn+ExwvRLtaixWsVW1q3OX3KXXe0l8VMLl4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "90f547b90e73d3c6025e66c5b742d6db51c418c3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "bun2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1748243702,
+        "narHash": "sha256-9YzfeN8CB6SzNPyPm2XjRRqSixDopTapaRsnTpXUEY8=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "1f3f7b784643d488ba4bf315638b2b0a4c5fb007",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,254 @@
+{
+  description = "Claudia - A Tauri application";
+
+  nixConfig = {
+    extra-substituters = [
+      "https://cache.nixos.org"
+      "https://cache.garnix.io"
+    ];
+    extra-trusted-public-keys = [
+      "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+      "cache.garnix.io:CTFPyKSLcx5RMKJfLo5EEPUObbA78b0YQ2DTCJXqr9g="
+    ];
+  };
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    bun2nix = {
+      url = "github:baileyluTCD/bun2nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, rust-overlay, bun2nix }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+          config = {
+            allowUnfree = true;
+          };
+        };
+        lib = pkgs.lib;
+        
+        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+          extensions = [ "rust-src" "rustfmt" ];
+        };
+
+        # Build dependencies
+        buildInputs = with pkgs; [
+          rustToolchain
+          pkg-config
+          openssl
+          sqlite
+          claude-code
+          # Graphics and display dependencies
+          libGL
+          libGLU
+          mesa
+          vulkan-loader
+          vulkan-validation-layers
+        ] ++ lib.optionals stdenv.isDarwin [
+          darwin.apple_sdk.frameworks.AppKit
+          darwin.apple_sdk.frameworks.WebKit
+          darwin.apple_sdk.frameworks.Security
+          darwin.apple_sdk.frameworks.CoreGraphics
+          darwin.apple_sdk.frameworks.CoreServices
+        ] ++ lib.optionals stdenv.isLinux [
+          gtk3
+          webkitgtk_4_1
+          libsoup_3
+          glib
+          cairo
+          gdk-pixbuf
+          pango
+          # Wayland support
+          wayland
+          wayland-protocols
+          libxkbcommon
+          # X11 fallback
+          xorg.libX11
+          xorg.libXrandr
+          xorg.libXi
+          xorg.libXcursor
+        ];
+
+        nativeBuildInputs = with pkgs; [
+          nodejs_20
+          bun
+          cargo-tauri
+          wrapGAppsHook3
+        ];
+
+      in
+      {
+        packages = {
+          default = self.packages.${system}.claudia;
+          
+          # Build the frontend using bun2nix
+          claudia-frontend = bun2nix.lib.${system}.mkBunDerivation {
+            pname = "claudia-frontend";
+            version = "0.1.0";
+            # Filter source to only include frontend files for better caching
+            src = lib.cleanSourceWith {
+              src = ./.;
+              filter = path: type:
+                let 
+                  baseName = baseNameOf path;
+                  relativePath = lib.removePrefix (toString ./. + "/") (toString path);
+                in
+                # Include essential files and frontend directories
+                (lib.hasPrefix "src/" relativePath) ||
+                (lib.hasPrefix "public/" relativePath) ||
+                (baseName == "package.json") ||
+                (baseName == "bun.lock") ||
+                (baseName == "bun.nix") ||
+                (baseName == "tsconfig.json") ||
+                (baseName == "tsconfig.node.json") ||
+                (baseName == "vite.config.ts") ||
+                (baseName == "tailwind.config.js") ||
+                (baseName == "postcss.config.js") ||
+                (baseName == "index.html") ||
+                (type == "directory" && !lib.hasPrefix "src-tauri/" relativePath && !lib.hasPrefix ".git/" relativePath && !lib.hasPrefix "target/" relativePath);
+            };
+            bunNix = ./bun.nix;
+            index = "src/main.tsx";
+            # Override install phase to build and copy our frontend
+            installPhase = ''
+              # Run the build
+              bun run build
+              
+              # Create output directory and copy built files
+              mkdir -p $out
+              cp -r dist $out/
+            '';
+          };
+          
+          claudia = pkgs.rustPlatform.buildRustPackage rec {
+            pname = "claudia";
+            version = "0.1.0";
+            
+            # Include all src-tauri files except nix-specific ones
+            src = lib.cleanSourceWith {
+              src = ./src-tauri;
+              filter = path: type:
+                let 
+                  baseName = baseNameOf path;
+                  relativePath = lib.removePrefix (toString ./src-tauri + "/") (toString path);
+                in
+                # Exclude nix-specific files but include everything else
+                !(lib.hasPrefix ".nix" baseName) &&
+                !(lib.hasSuffix ".nix" baseName) &&
+                !(baseName == "flake.lock") &&
+                !(baseName == "flake.nix");
+            };
+            
+            cargoLock = {
+              lockFile = ./src-tauri/Cargo.lock;
+            };
+            
+            # Don't run tests during build
+            doCheck = false;
+            
+            inherit buildInputs;
+            
+            nativeBuildInputs = with pkgs; [
+              pkg-config
+              rustToolchain
+              nodejs_20
+              bun
+              cargo-tauri
+              wrapGAppsHook3
+              copyDesktopItems
+              makeWrapper
+            ];
+            
+            # Copy pre-built frontend before building
+            preBuild = ''
+              # We're in src-tauri directory, Tauri expects dist to be at ../dist
+              mkdir -p ../dist
+              cp -r ${self.packages.${system}.claudia-frontend}/dist/* ../dist/
+              
+              # Modify tauri.conf.json to remove beforeBuildCommand since we already built frontend
+              ${pkgs.jq}/bin/jq '.build.beforeBuildCommand = ""' tauri.conf.json > tauri.conf.json.tmp
+              mv tauri.conf.json.tmp tauri.conf.json
+              
+              # CRITICAL: Set up for cargo-tauri build
+              export CARGO_BUILD_TARGET_DIR="target"
+            '';
+            
+            # Override build phase to use cargo-tauri
+            buildPhase = ''
+              runHook preBuild
+              
+              # Build with cargo-tauri to properly embed assets
+              ${pkgs.cargo-tauri}/bin/cargo-tauri build --no-bundle
+              
+              runHook postBuild
+            '';
+            
+            # Custom install since we're not using bundles
+            installPhase = ''
+              runHook preInstall
+              
+              # Install the built binary
+              mkdir -p $out/bin
+              cp target/release/claudia $out/bin/
+              
+              # Install desktop files and icons on Linux
+              ${lib.optionalString (pkgs.stdenv.isLinux) ''
+                mkdir -p $out/share/icons/hicolor/128x128/apps
+                if [[ -f icons/128x128.png ]]; then
+                  cp icons/128x128.png $out/share/icons/hicolor/128x128/apps/claudia.png
+                fi
+              ''}
+              
+              runHook postInstall
+            '';
+            
+            # wrapGAppsHook3 handles most of the wrapping automatically
+            dontWrapGApps = true;
+            
+            postFixup = ''
+              # Manually wrap with additional Tauri-specific environment variables
+              wrapGApp $out/bin/claudia \
+                --set WEBKIT_DISABLE_COMPOSITING_MODE "1" \
+                --set LIBGL_ALWAYS_SOFTWARE "1" \
+                --set GALLIUM_DRIVER "llvmpipe"
+            '';
+            
+            desktopItems = lib.optionals pkgs.stdenv.isLinux [
+              (pkgs.makeDesktopItem {
+                name = "claudia";
+                exec = "claudia";
+                icon = "claudia";
+                desktopName = "Claudia";
+                comment = "A Tauri application";
+                categories = [ "Utility" ];
+              })
+            ];
+          };
+        };
+        
+        devShells.default = pkgs.mkShell {
+          buildInputs = buildInputs ++ nativeBuildInputs ++ [
+            bun2nix.packages.${system}.default
+          ];
+          
+          shellHook = ''
+            echo "Claudia development environment"
+            echo "Run 'bun install' to install dependencies"
+            echo "Run 'bun run tauri dev' to start development server"
+            echo ""
+            echo "To generate bun.nix for Nix builds:"
+            echo "  bun2nix -o bun.nix"
+          '';
+        };
+      });
+}


### PR DESCRIPTION
Add Nix flake with proper Tauri v2 build configuration that resolves both asset embedding and graphics driver issues on NixOS.

Key changes:
- Add flake.nix with separate frontend and backend builds
- Use bun2nix for frontend build with proper filtering
- Use cargo-tauri for Rust build to embed assets correctly
- Modify tauri.conf.json during build to skip frontend rebuild
- Add software rendering fallback for OpenGL compatibility
- Use wrapGAppsHook3 for proper GTK/WebKit integration
- Add result/ to .gitignore and .envrc for direnv support

The application now builds and runs successfully on NixOS without requiring manual driver configuration or external dependencies.

I've only tested this on wayland/hyprland so far.