### PR TITLE
feat: Add macOS automated installation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,21 @@ Menu → MCP Manager → Add Server → Configure
 
 - **Claude Code CLI**: Install from [Claude's official site](https://claude.ai/code)
 
+### macOS Quick Install
+
+For macOS users, you can use our automated installation script:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/getAsterisk/claudia/main/scripts/macos/install.sh | bash
+```
+
+This script will:
+- Check all dependencies (Rust, Bun, Git)
+- Clone and build Claudia
+- Install it to your Applications folder
+
+For more details, see [macOS installation scripts](scripts/macos/README.md).
+
 ### Release Executables Will Be Published Soon
 
 ## 🔨 Build from Source

--- a/scripts/macos/README.md
+++ b/scripts/macos/README.md
@@ -1,0 +1,56 @@
+# macOS Installation Scripts
+
+This directory contains automated installation scripts for Claudia on macOS.
+
+## Scripts
+
+### install.sh
+Complete installation script that:
+- Checks all dependencies (Rust, Bun, Git)
+- Clones the repository
+- Builds the application
+- Installs to `/Applications`
+- Optional cleanup of build files
+
+### update.sh
+Quick update script for existing installations that:
+- Pulls latest code
+- Rebuilds the application
+- Replaces the existing app
+- Backs up the old version
+
+## Usage
+
+### First Installation
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/getAsterisk/claudia/main/scripts/macos/install.sh | bash
+```
+
+Or download and run locally:
+
+```bash
+chmod +x install.sh
+./install.sh
+```
+
+### Updating
+
+```bash
+chmod +x update.sh
+./update.sh
+```
+
+## Prerequisites
+
+The scripts will check for:
+- **Rust** (1.70.0+): `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
+- **Bun** (latest): `curl -fsSL https://bun.sh/install | bash`
+- **Git**: Usually pre-installed on macOS
+- **Xcode Command Line Tools**: `xcode-select --install`
+
+## Notes
+
+- First run: macOS may show a security warning. Click "Open" or allow in System Settings.
+- DMG bundling may fail but doesn't affect the .app creation
+- Build time: 5-10 minutes on first build, depending on network and machine performance

--- a/scripts/macos/install.sh
+++ b/scripts/macos/install.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+# Claudia macOS Installation Script
+# Automates the complete installation process from GitHub to Applications folder
+
+set -e  # Exit on error
+
+echo "🚀 Starting Claudia installation for macOS..."
+
+# 1. Check dependencies
+echo "📋 Checking dependencies..."
+
+# Check Rust
+if ! command -v rustc &> /dev/null; then
+    echo "❌ Rust not installed. Please install Rust first:"
+    echo "   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
+    exit 1
+fi
+echo "✅ Rust installed: $(rustc --version)"
+
+# Check Bun
+if ! command -v bun &> /dev/null; then
+    echo "❌ Bun not installed. Please install Bun first:"
+    echo "   curl -fsSL https://bun.sh/install | bash"
+    exit 1
+fi
+echo "✅ Bun installed: $(bun --version)"
+
+# Check Git
+if ! command -v git &> /dev/null; then
+    echo "❌ Git not installed"
+    exit 1
+fi
+echo "✅ Git installed"
+
+# 2. Choose installation directory
+INSTALL_DIR="$HOME/claudia-build"
+if [ -d "$INSTALL_DIR" ]; then
+    echo "⚠️  Directory $INSTALL_DIR already exists"
+    read -p "Delete and reinstall? (y/n): " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        rm -rf "$INSTALL_DIR"
+    else
+        echo "❌ Installation cancelled"
+        exit 1
+    fi
+fi
+
+# 3. Clone repository
+echo "📦 Cloning Claudia repository..."
+git clone https://github.com/getAsterisk/claudia.git "$INSTALL_DIR"
+cd "$INSTALL_DIR"
+
+# 4. Install dependencies
+echo "📚 Installing project dependencies..."
+bun install
+
+# 5. Build application
+echo "🔨 Building Claudia (this may take a few minutes)..."
+bun run tauri build --no-bundle || {
+    echo "⚠️  DMG bundling failed, but .app should be created"
+}
+
+# 6. Check build result
+APP_PATH="$INSTALL_DIR/src-tauri/target/release/bundle/macos/Claudia.app"
+if [ ! -d "$APP_PATH" ]; then
+    echo "❌ Build failed: Claudia.app not found"
+    exit 1
+fi
+
+echo "✅ Claudia.app built successfully!"
+
+# 7. Install to Applications
+echo "📱 Installing Claudia to Applications folder..."
+
+# Check if already exists
+if [ -d "/Applications/Claudia.app" ]; then
+    echo "⚠️  /Applications/Claudia.app already exists"
+    read -p "Overwrite? (y/n): " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        rm -rf "/Applications/Claudia.app"
+    else
+        echo "❌ Installation cancelled"
+        exit 1
+    fi
+fi
+
+# Copy to Applications
+cp -r "$APP_PATH" /Applications/
+
+# 8. Cleanup (optional)
+read -p "Delete build directory to save space? (y/n): " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    cd "$HOME"
+    rm -rf "$INSTALL_DIR"
+    echo "✅ Build directory cleaned up"
+fi
+
+echo "🎉 Claudia installation complete!"
+echo ""
+echo "📌 How to use:"
+echo "   1. Open Claudia from Launchpad"
+echo "   2. Or from Finder → Applications → Claudia"
+echo "   3. Or use Spotlight search for 'Claudia'"
+echo ""
+echo "⚠️  First run: macOS may show a security warning"
+echo "   Click 'Open' or allow in System Settings"
+
+# Ask to launch
+read -p "Launch Claudia now? (y/n): " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    open /Applications/Claudia.app
+fi

--- a/scripts/macos/update.sh
+++ b/scripts/macos/update.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Claudia macOS Update Script
+# Quick update for existing installations
+
+set -e
+
+echo "🔄 Updating Claudia..."
+
+# Default to existing claudia directory
+CLAUDIA_DIR="$HOME/claudia"
+
+if [ ! -d "$CLAUDIA_DIR" ]; then
+    echo "❌ Claudia directory not found: $CLAUDIA_DIR"
+    echo "Please run install.sh for initial installation"
+    exit 1
+fi
+
+cd "$CLAUDIA_DIR"
+
+# Update code
+echo "📥 Pulling latest code..."
+git pull
+
+# Update dependencies
+echo "📦 Updating dependencies..."
+bun install
+
+# Build
+echo "🔨 Building new version..."
+bun run tauri build --no-bundle || true
+
+# Check build result
+APP_PATH="$CLAUDIA_DIR/src-tauri/target/release/bundle/macos/Claudia.app"
+if [ ! -d "$APP_PATH" ]; then
+    echo "❌ Build failed"
+    exit 1
+fi
+
+# Kill running Claudia
+echo "🔄 Preparing to replace app..."
+killall Claudia 2>/dev/null || true
+
+# Backup old version (optional)
+if [ -d "/Applications/Claudia.app" ]; then
+    echo "📋 Backing up old version..."
+    rm -rf "/Applications/Claudia.app.backup"
+    mv "/Applications/Claudia.app" "/Applications/Claudia.app.backup"
+fi
+
+# Install new version
+echo "📱 Installing new version..."
+cp -r "$APP_PATH" /Applications/
+
+echo "✅ Claudia updated successfully!"
+
+# Launch new version
+read -p "Launch new version? (y/n): " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    open /Applications/Claudia.app
+fi


### PR DESCRIPTION
## Description

This PR adds automated installation scripts for macOS users to simplify the setup process.

## Changes

- Added `scripts/macos/install.sh` - Complete installation script
- Added `scripts/macos/update.sh` - Quick update script for existing installations
- Added `scripts/macos/README.md` with detailed usage instructions
- Updated main README.md with quick install command

## Usage

### Quick Install (after merge)
```bash
curl -fsSL https://raw.githubusercontent.com/getAsterisk/claudia/main/scripts/macos/install.sh | bash
```

## Testing

- Tested on macOS 14.4 (M1)
- Successfully builds and installs Claudia.app

## Related

Closes #140