### PR TITLE
Fix NVM Node.js PATH issue for locally installed Claude

### DIFF
--- a/src-tauri/src/commands/claude.rs
+++ b/src-tauri/src/commands/claude.rs
@@ -226,7 +226,7 @@ fn extract_first_user_message(jsonl_path: &PathBuf) -> (Option<String>, Option<S
 /// This ensures commands like Claude can find Node.js and other dependencies
 fn create_command_with_env(program: &str) -> Command {
     // Convert std::process::Command to tokio::process::Command
-    let _std_cmd = crate::claude_binary::create_command_with_env(program);
+    let std_cmd = crate::claude_binary::create_command_with_env(program);
 
     // Create a new tokio Command from the program path
     let mut tokio_cmd = Command::new(program);
@@ -272,6 +272,19 @@ fn create_command_with_env(program: &str) -> Command {
                 let new_path = format!("{}:{}", homebrew_bin_str, current_path);
                 log::debug!("Adding Homebrew bin directory to PATH: {}", homebrew_bin_str);
                 tokio_cmd.env("PATH", new_path);
+            }
+        }
+    }
+    
+    // Only use enhanced PATH if Claude is NOT in NVM but needs Node from NVM (our specific fix)
+    if !program.contains("/.nvm/versions/node/") {
+        if let Some(enhanced_path) = std_cmd.get_envs().find_map(|(k, v)| {
+            if k == "PATH" { v.and_then(|val| val.to_str().map(String::from)) } else { None }
+        }) {
+            // Only override if the enhanced PATH added NVM paths
+            if enhanced_path.contains("/.nvm/versions/node/") {
+                log::debug!("Claude not in NVM but needs Node - using enhanced PATH with NVM: {}", enhanced_path);
+                tokio_cmd.env("PATH", enhanced_path);
             }
         }
     }


### PR DESCRIPTION
## Problem
When opcode is launched from /Applications folder on macOS, it receives a minimal PATH environment that doesn't include NVM directories. This causes Claude commands to fail with "env: node: No such file or directory" for users with npm-local Claude installations that depend on Node.js from NVM.

## Root Cause
The existing code had an unused `_std_cmd` variable in `commands/claude.rs` that was creating an enhanced PATH but never using it. Additionally, NVM path detection only worked when Claude itself was installed in an NVM directory, not when Claude was elsewhere but needed Node.js from NVM.

## Solution
This PR provides a minimal, targeted fix:

1. **Fixed unused variable**: Removed underscore from `_std_cmd` so the enhanced PATH is actually used
2. **Added NVM detection**: Added an else clause in `claude_binary.rs` to detect and add NVM Node.js paths even when Claude isn't installed via NVM
3. **Targeted override**: Added a conditional override that ONLY applies when Claude is NOT in NVM but needs Node.js from NVM

## Changes
- `src-tauri/src/claude_binary.rs`: Added else clause for NVM detection when Claude needs Node but isn't in NVM
- `src-tauri/src/commands/claude.rs`: Fixed unused `_std_cmd` and added targeted PATH override

## Testing
- Built and tested DMG on macOS with Claude installed via npm-local
- Verified the fix works when opcode is launched from /Applications
- The fix only triggers for the specific edge case (Claude not in NVM but needing Node from NVM)
- **Note**: Tested and confirmed working on macOS where the edge case was occurring. Not tested on other environments or operating systems.

## Impact
- **Zero impact on other installation types** - the override only happens when Claude is NOT in an NVM directory but the enhanced PATH contains NVM paths
- No changes to existing logic flow - all existing code runs first, our fix applies last only when needed
- Platform-safe: NVM path detection only adds paths if they exist

Fixes the issue where npm-local Claude installations fail when opcode is launched from /Applications due to missing Node.js in PATH.