### PR TITLE
fix: add missing installation_type in NVM_BIN ClaudeInstallation

### DIFF
--- a/src-tauri/src/claude_binary.rs
+++ b/src-tauri/src/claude_binary.rs
@@ -223,6 +223,7 @@ fn find_nvm_installations() -> Vec<ClaudeInstallation> {
                 path: claude_path.to_string_lossy().to_string(),
                 version,
                 source: "nvm-active".to_string(),
+                installation_type: InstallationType::System,
             });
         }
     }


### PR DESCRIPTION
## Summary
When running the Tauri dev build, compilation failed with E0063 due to a missing
`installation_type` field in the `ClaudeInstallation` initializer for the `NVM_BIN`
detection path.

This PR adds:
- `installation_type: InstallationType::System` to the NVM_BIN path, matching the
  existing behavior used in the NVM directory scan.

## Reproduction
```bash
# dev build
bun run tauri dev
# or
cd src-tauri && cargo build
```

## Error
```rust
error[E0063]: missing field `installation_type` in initializer of `ClaudeInstallation`
   --> src/claude_binary.rs:222:32
    |
222 |             installations.push(ClaudeInstallation {
    |                                ^^^^^^^^^^^^^^^^^^ missing `installation_type`
```