### PR TITLE
Fix missing installation_type field in ClaudeInstallation struct

### DIFF
--- a/src-tauri/src/claude_binary.rs
+++ b/src-tauri/src/claude_binary.rs
@@ -223,6 +223,7 @@ fn find_nvm_installations() -> Vec<ClaudeInstallation> {
                 path: claude_path.to_string_lossy().to_string(),
                 version,
                 source: "nvm-active".to_string(),
+                installation_type: InstallationType::System,
             });
         }
     }


### PR DESCRIPTION
## Description

This PR fixes a compilation error in the Rust code that was preventing successful builds of the Tauri application.

## Problem

The build was failing with the following error:
```
error[E0063]: missing field `installation_type` in initializer of `ClaudeInstallation`
   --> src/claude_binary.rs:222:32
    |
222 |             installations.push(ClaudeInstallation {
    |                                ^^^^^^^^^^^^^^^^^^ missing `installation_type`
```

## Root Cause

In the `find_nvm_installations()` function at line 222, one instance of `ClaudeInstallation` struct initialization was missing the required `installation_type` field. This field was added to the struct definition but this particular initialization was not updated.

## Solution

- Added the missing `installation_type: InstallationType::System` field to the `ClaudeInstallation` initialization
- This matches the pattern used by other NVM installations in the same function and throughout the codebase
- The fix ensures consistency with the struct definition and allows successful compilation

## Testing

- ✅ Build now completes successfully for `aarch64-apple-darwin` target
- ✅ The fix maintains consistency with other `ClaudeInstallation` initializations in the codebase
- ✅ No functional changes to the behavior, only structural compliance

## Files Changed

- `src-tauri/src/claude_binary.rs` - Added missing `installation_type` field

This is a minimal, targeted fix that resolves the immediate build issue while maintaining code consistency.