### PR TITLE
Fix: project paths with hyphens incorrectly parsed

### DIFF
--- a/src-tauri/src/claude_binary.rs
+++ b/src-tauri/src/claude_binary.rs
@@ -223,6 +223,7 @@ fn find_nvm_installations() -> Vec<ClaudeInstallation> {
                 path: claude_path.to_string_lossy().to_string(),
                 version,
                 source: "nvm-active".to_string(),
+                installation_type: InstallationType::System,
             });
         }
     }


### PR DESCRIPTION
Projects with hyphens in their paths (e.g., `data-discovery`) were being incorrectly displayed with the hyphen replaced by a slash (`data/discovery`).

Root cause: The `get_project_path_from_sessions()` function only checked the first line of session `JSONL` files for the 'cwd' field. Some session files have null cwd on the first line, causing the fallback to the buggy `decode_project_path()` which blindly replaces all hyphens with slashes.

Fix: Check up to the first 10 lines of session files to find a valid, non-empty cwd value before falling back to path decoding.

Also fixes compilation error in claude_binary.rs where ClaudeInstallation was missing the installation_type field for NVM installations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)