### PR TITLE
fix(web): use wss:// for HTTPS connections and apply cargo fmt

### DIFF
--- a/src-tauri/src/claude_binary.rs
+++ b/src-tauri/src/claude_binary.rs
@@ -47,7 +47,7 @@ pub fn find_claude_binary(app_handle: &tauri::AppHandle) -> Result<String, Strin
                     |row| row.get::<_, String>(0),
                 ) {
                     info!("Found stored claude path in database: {}", stored_path);
-                    
+
                     // Check if the path still exists
                     let path_buf = PathBuf::from(&stored_path);
                     if path_buf.exists() && path_buf.is_file() {
@@ -56,14 +56,14 @@ pub fn find_claude_binary(app_handle: &tauri::AppHandle) -> Result<String, Strin
                         warn!("Stored claude path no longer exists: {}", stored_path);
                     }
                 }
-                
+
                 // Check user preference
                 let preference = conn.query_row(
                     "SELECT value FROM app_settings WHERE key = 'claude_installation_preference'",
                     [],
                     |row| row.get::<_, String>(0),
                 ).unwrap_or_else(|_| "system".to_string());
-                
+
                 info!("User preference for Claude installation: {}", preference);
             }
         }
@@ -261,7 +261,9 @@ fn find_nvm_installations() -> Vec<ClaudeInstallation> {
         let claude_path = PathBuf::from(&nvm_bin).join("claude");
         if claude_path.exists() && claude_path.is_file() {
             debug!("Found Claude via NVM_BIN: {:?}", claude_path);
-            let version = get_claude_version(&claude_path.to_string_lossy()).ok().flatten();
+            let version = get_claude_version(&claude_path.to_string_lossy())
+                .ok()
+                .flatten();
             installations.push(ClaudeInstallation {
                 path: claude_path.to_string_lossy().to_string(),
                 version,
@@ -496,7 +498,6 @@ fn find_standard_installations() -> Vec<ClaudeInstallation> {
     installations
 }
 
-
 /// Get Claude version by running --version command
 fn get_claude_version(path: &str) -> Result<Option<String>, String> {
     match Command::new(path).arg("--version").output() {
@@ -517,10 +518,10 @@ fn get_claude_version(path: &str) -> Result<Option<String>, String> {
 /// Extract version string from command output
 fn extract_version_from_output(stdout: &[u8]) -> Option<String> {
     let output_str = String::from_utf8_lossy(stdout);
-    
+
     // Debug log the raw output
     debug!("Raw version output: {:?}", output_str);
-    
+
     // Use regex to directly extract version pattern (e.g., "1.0.41")
     // This pattern matches:
     // - One or more digits, followed by
@@ -529,8 +530,9 @@ fn extract_version_from_output(stdout: &[u8]) -> Option<String> {
     // - A dot, followed by
     // - One or more digits
     // - Optionally followed by pre-release/build metadata
-    let version_regex = regex::Regex::new(r"(\d+\.\d+\.\d+(?:-[a-zA-Z0-9.-]+)?(?:\+[a-zA-Z0-9.-]+)?)").ok()?;
-    
+    let version_regex =
+        regex::Regex::new(r"(\d+\.\d+\.\d+(?:-[a-zA-Z0-9.-]+)?(?:\+[a-zA-Z0-9.-]+)?)").ok()?;
+
     if let Some(captures) = version_regex.captures(&output_str) {
         if let Some(version_match) = captures.get(1) {
             let version = version_match.as_str().to_string();
@@ -538,7 +540,7 @@ fn extract_version_from_output(stdout: &[u8]) -> Option<String> {
             return Some(version);
         }
     }
-    
+
     debug!("No version found in output");
     None
 }
@@ -618,7 +620,7 @@ fn compare_versions(a: &str, b: &str) -> Ordering {
 /// This ensures commands like Claude can find Node.js and other dependencies
 pub fn create_command_with_env(program: &str) -> Command {
     let mut cmd = Command::new(program);
-    
+
     info!("Creating command for: {}", program);
 
     // Inherit essential environment variables from parent process
@@ -646,7 +648,7 @@ pub fn create_command_with_env(program: &str) -> Command {
             cmd.env(&key, &value);
         }
     }
-    
+
     // Log proxy-related environment variables for debugging
     info!("Command will use proxy settings:");
     if let Ok(http_proxy) = std::env::var("HTTP_PROXY") {
@@ -669,7 +671,7 @@ pub fn create_command_with_env(program: &str) -> Command {
             }
         }
     }
-    
+
     // Add Homebrew support if the program is in a Homebrew directory
     if program.contains("/homebrew/") || program.contains("/opt/homebrew/") {
         if let Some(program_dir) = std::path::Path::new(program).parent() {
@@ -678,7 +680,10 @@ pub fn create_command_with_env(program: &str) -> Command {
             let homebrew_bin_str = program_dir.to_string_lossy();
             if !current_path.contains(&homebrew_bin_str.as_ref()) {
                 let new_path = format!("{}:{}", homebrew_bin_str, current_path);
-                debug!("Adding Homebrew bin directory to PATH: {}", homebrew_bin_str);
+                debug!(
+                    "Adding Homebrew bin directory to PATH: {}",
+                    homebrew_bin_str
+                );
                 cmd.env("PATH", new_path);
             }
         }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,7 +1,7 @@
 pub mod agents;
 pub mod claude;
 pub mod mcp;
-pub mod usage;
-pub mod storage;
-pub mod slash_commands;
 pub mod proxy;
+pub mod slash_commands;
+pub mod storage;
+pub mod usage;

--- a/src-tauri/src/commands/proxy.rs
+++ b/src-tauri/src/commands/proxy.rs
@@ -1,6 +1,6 @@
+use rusqlite::params;
 use serde::{Deserialize, Serialize};
 use tauri::State;
-use rusqlite::params;
 
 use crate::commands::agents::AgentDb;
 
@@ -29,9 +29,9 @@ impl Default for ProxySettings {
 #[tauri::command]
 pub async fn get_proxy_settings(db: State<'_, AgentDb>) -> Result<ProxySettings, String> {
     let conn = db.0.lock().map_err(|e| e.to_string())?;
-    
+
     let mut settings = ProxySettings::default();
-    
+
     // Query each proxy setting
     let keys = vec![
         ("proxy_enabled", "enabled"),
@@ -40,7 +40,7 @@ pub async fn get_proxy_settings(db: State<'_, AgentDb>) -> Result<ProxySettings,
         ("proxy_no", "no_proxy"),
         ("proxy_all", "all_proxy"),
     ];
-    
+
     for (db_key, field) in keys {
         if let Ok(value) = conn.query_row(
             "SELECT value FROM app_settings WHERE key = ?1",
@@ -57,7 +57,7 @@ pub async fn get_proxy_settings(db: State<'_, AgentDb>) -> Result<ProxySettings,
             }
         }
     }
-    
+
     Ok(settings)
 }
 
@@ -68,33 +68,40 @@ pub async fn save_proxy_settings(
     settings: ProxySettings,
 ) -> Result<(), String> {
     let conn = db.0.lock().map_err(|e| e.to_string())?;
-    
+
     // Save each setting
     let values = vec![
         ("proxy_enabled", settings.enabled.to_string()),
-        ("proxy_http", settings.http_proxy.clone().unwrap_or_default()),
-        ("proxy_https", settings.https_proxy.clone().unwrap_or_default()),
+        (
+            "proxy_http",
+            settings.http_proxy.clone().unwrap_or_default(),
+        ),
+        (
+            "proxy_https",
+            settings.https_proxy.clone().unwrap_or_default(),
+        ),
         ("proxy_no", settings.no_proxy.clone().unwrap_or_default()),
         ("proxy_all", settings.all_proxy.clone().unwrap_or_default()),
     ];
-    
+
     for (key, value) in values {
         conn.execute(
             "INSERT OR REPLACE INTO app_settings (key, value) VALUES (?1, ?2)",
             params![key, value],
-        ).map_err(|e| format!("Failed to save {}: {}", key, e))?;
+        )
+        .map_err(|e| format!("Failed to save {}: {}", key, e))?;
     }
-    
+
     // Apply the proxy settings immediately to the current process
     apply_proxy_settings(&settings);
-    
+
     Ok(())
 }
 
 /// Apply proxy settings as environment variables
 pub fn apply_proxy_settings(settings: &ProxySettings) {
     log::info!("Applying proxy settings: enabled={}", settings.enabled);
-    
+
     if !settings.enabled {
         // Clear proxy environment variables if disabled
         log::info!("Clearing proxy environment variables");
@@ -109,7 +116,7 @@ pub fn apply_proxy_settings(settings: &ProxySettings) {
         std::env::remove_var("all_proxy");
         return;
     }
-    
+
     // Ensure NO_PROXY includes localhost by default
     let mut no_proxy_list = vec!["localhost", "127.0.0.1", "::1", "0.0.0.0"];
     if let Some(user_no_proxy) = &settings.no_proxy {
@@ -118,7 +125,7 @@ pub fn apply_proxy_settings(settings: &ProxySettings) {
         }
     }
     let no_proxy_value = no_proxy_list.join(",");
-    
+
     // Set proxy environment variables (uppercase is standard)
     if let Some(http_proxy) = &settings.http_proxy {
         if !http_proxy.is_empty() {
@@ -126,25 +133,25 @@ pub fn apply_proxy_settings(settings: &ProxySettings) {
             std::env::set_var("HTTP_PROXY", http_proxy);
         }
     }
-    
+
     if let Some(https_proxy) = &settings.https_proxy {
         if !https_proxy.is_empty() {
             log::info!("Setting HTTPS_PROXY={}", https_proxy);
             std::env::set_var("HTTPS_PROXY", https_proxy);
         }
     }
-    
+
     // Always set NO_PROXY to include localhost
     log::info!("Setting NO_PROXY={}", no_proxy_value);
     std::env::set_var("NO_PROXY", &no_proxy_value);
-    
+
     if let Some(all_proxy) = &settings.all_proxy {
         if !all_proxy.is_empty() {
             log::info!("Setting ALL_PROXY={}", all_proxy);
             std::env::set_var("ALL_PROXY", all_proxy);
         }
     }
-    
+
     // Log current proxy environment variables for debugging
     log::info!("Current proxy environment variables:");
     for (key, value) in std::env::vars() {

--- a/src-tauri/src/commands/slash_commands.rs
+++ b/src-tauri/src/commands/slash_commands.rs
@@ -45,13 +45,13 @@ struct CommandFrontmatter {
 /// Parse a markdown file with optional YAML frontmatter
 fn parse_markdown_with_frontmatter(content: &str) -> Result<(Option<CommandFrontmatter>, String)> {
     let lines: Vec<&str> = content.lines().collect();
-    
+
     // Check if the file starts with YAML frontmatter
     if lines.is_empty() || lines[0] != "---" {
         // No frontmatter
         return Ok((None, content.to_string()));
     }
-    
+
     // Find the end of frontmatter
     let mut frontmatter_end = None;
     for (i, line) in lines.iter().enumerate().skip(1) {
@@ -60,12 +60,12 @@ fn parse_markdown_with_frontmatter(content: &str) -> Result<(Option<CommandFront
             break;
         }
     }
-    
+
     if let Some(end) = frontmatter_end {
         // Extract frontmatter
         let frontmatter_content = lines[1..end].join("\n");
         let body_content = lines[(end + 1)..].join("\n");
-        
+
         // Parse YAML
         match serde_yaml::from_str::<CommandFrontmatter>(&frontmatter_content) {
             Ok(frontmatter) => Ok((Some(frontmatter), body_content)),
@@ -86,20 +86,20 @@ fn extract_command_info(file_path: &Path, base_path: &Path) -> Result<(String, O
     let relative_path = file_path
         .strip_prefix(base_path)
         .context("Failed to get relative path")?;
-    
+
     // Remove .md extension
     let path_without_ext = relative_path
         .with_extension("")
         .to_string_lossy()
         .to_string();
-    
+
     // Split into components
     let components: Vec<&str> = path_without_ext.split('/').collect();
-    
+
     if components.is_empty() {
         return Err(anyhow::anyhow!("Invalid command path"));
     }
-    
+
     if components.len() == 1 {
         // No namespace
         Ok((components[0].to_string(), None))
@@ -112,44 +112,43 @@ fn extract_command_info(file_path: &Path, base_path: &Path) -> Result<(String, O
 }
 
 /// Load a single command from a markdown file
-fn load_command_from_file(
-    file_path: &Path,
-    base_path: &Path,
-    scope: &str,
-) -> Result<SlashCommand> {
+fn load_command_from_file(file_path: &Path, base_path: &Path, scope: &str) -> Result<SlashCommand> {
     debug!("Loading command from: {:?}", file_path);
-    
+
     // Read file content
-    let content = fs::read_to_string(file_path)
-        .context("Failed to read command file")?;
-    
+    let content = fs::read_to_string(file_path).context("Failed to read command file")?;
+
     // Parse frontmatter
     let (frontmatter, body) = parse_markdown_with_frontmatter(&content)?;
-    
+
     // Extract command info
     let (name, namespace) = extract_command_info(file_path, base_path)?;
-    
+
     // Build full command (no scope prefix, just /command or /namespace:command)
     let full_command = match &namespace {
         Some(ns) => format!("/{ns}:{name}"),
         None => format!("/{name}"),
     };
-    
+
     // Generate unique ID
-    let id = format!("{}-{}", scope, file_path.to_string_lossy().replace('/', "-"));
-    
+    let id = format!(
+        "{}-{}",
+        scope,
+        file_path.to_string_lossy().replace('/', "-")
+    );
+
     // Check for special content
     let has_bash_commands = body.contains("!`");
     let has_file_references = body.contains('@');
     let accepts_arguments = body.contains("$ARGUMENTS");
-    
+
     // Extract metadata from frontmatter
     let (description, allowed_tools) = if let Some(fm) = frontmatter {
         (fm.description, fm.allowed_tools.unwrap_or_default())
     } else {
         (None, Vec::new())
     };
-    
+
     Ok(SlashCommand {
         id,
         name,
@@ -171,18 +170,18 @@ fn find_markdown_files(dir: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
     if !dir.exists() {
         return Ok(());
     }
-    
+
     for entry in fs::read_dir(dir)? {
         let entry = entry?;
         let path = entry.path();
-        
+
         // Skip hidden files/directories
         if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
             if name.starts_with('.') {
                 continue;
             }
         }
-        
+
         if path.is_dir() {
             find_markdown_files(&path, files)?;
         } else if path.is_file() {
@@ -193,7 +192,7 @@ fn find_markdown_files(dir: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
             }
         }
     }
-    
+
     Ok(())
 }
 
@@ -252,16 +251,16 @@ pub async fn slash_commands_list(
 ) -> Result<Vec<SlashCommand>, String> {
     info!("Discovering slash commands");
     let mut commands = Vec::new();
-    
+
     // Add default commands
     commands.extend(create_default_commands());
-    
+
     // Load project commands if project path is provided
     if let Some(proj_path) = project_path {
         let project_commands_dir = PathBuf::from(&proj_path).join(".claude").join("commands");
         if project_commands_dir.exists() {
             debug!("Scanning project commands at: {:?}", project_commands_dir);
-            
+
             let mut md_files = Vec::new();
             if let Err(e) = find_markdown_files(&project_commands_dir, &mut md_files) {
                 error!("Failed to find project command files: {}", e);
@@ -280,13 +279,13 @@ pub async fn slash_commands_list(
             }
         }
     }
-    
+
     // Load user commands
     if let Some(home_dir) = dirs::home_dir() {
         let user_commands_dir = home_dir.join(".claude").join("commands");
         if user_commands_dir.exists() {
             debug!("Scanning user commands at: {:?}", user_commands_dir);
-            
+
             let mut md_files = Vec::new();
             if let Err(e) = find_markdown_files(&user_commands_dir, &mut md_files) {
                 error!("Failed to find user command files: {}", e);
@@ -305,7 +304,7 @@ pub async fn slash_commands_list(
             }
         }
     }
-    
+
     info!("Found {} slash commands", commands.len());
     Ok(commands)
 }
@@ -314,17 +313,17 @@ pub async fn slash_commands_list(
 #[tauri::command]
 pub async fn slash_command_get(command_id: String) -> Result<SlashCommand, String> {
     debug!("Getting slash command: {}", command_id);
-    
+
     // Parse the ID to determine scope and reconstruct file path
     let parts: Vec<&str> = command_id.split('-').collect();
     if parts.len() < 2 {
         return Err("Invalid command ID".to_string());
     }
-    
+
     // The actual implementation would need to reconstruct the path and reload the command
     // For now, we'll list all commands and find the matching one
     let commands = slash_commands_list(None).await?;
-    
+
     commands
         .into_iter()
         .find(|cmd| cmd.id == command_id)
@@ -343,16 +342,16 @@ pub async fn slash_command_save(
     project_path: Option<String>,
 ) -> Result<SlashCommand, String> {
     info!("Saving slash command: {} in scope: {}", name, scope);
-    
+
     // Validate inputs
     if name.is_empty() {
         return Err("Command name cannot be empty".to_string());
     }
-    
+
     if !["project", "user"].contains(&scope.as_str()) {
         return Err("Invalid scope. Must be 'project' or 'user'".to_string());
     }
-    
+
     // Determine base directory
     let base_dir = if scope == "project" {
         if let Some(proj_path) = project_path {
@@ -366,7 +365,7 @@ pub async fn slash_command_save(
             .join(".claude")
             .join("commands")
     };
-    
+
     // Build file path
     let mut file_path = base_dir.clone();
     if let Some(ns) = &namespace {
@@ -374,41 +373,40 @@ pub async fn slash_command_save(
             file_path = file_path.join(component);
         }
     }
-    
+
     // Create directories if needed
-    fs::create_dir_all(&file_path)
-        .map_err(|e| format!("Failed to create directories: {}", e))?;
-    
+    fs::create_dir_all(&file_path).map_err(|e| format!("Failed to create directories: {}", e))?;
+
     // Add filename
     file_path = file_path.join(format!("{}.md", name));
-    
+
     // Build content with frontmatter
     let mut full_content = String::new();
-    
+
     // Add frontmatter if we have metadata
     if description.is_some() || !allowed_tools.is_empty() {
         full_content.push_str("---\n");
-        
+
         if let Some(desc) = &description {
             full_content.push_str(&format!("description: {}\n", desc));
         }
-        
+
         if !allowed_tools.is_empty() {
             full_content.push_str("allowed-tools:\n");
             for tool in &allowed_tools {
                 full_content.push_str(&format!("  - {}\n", tool));
             }
         }
-        
+
         full_content.push_str("---\n\n");
     }
-    
+
     full_content.push_str(&content);
-    
+
     // Write file
     fs::write(&file_path, &full_content)
         .map_err(|e| format!("Failed to write command file: {}", e))?;
-    
+
     // Load and return the saved command
     load_command_from_file(&file_path, &base_dir, &scope)
         .map_err(|e| format!("Failed to load saved command: {}", e))
@@ -416,35 +414,38 @@ pub async fn slash_command_save(
 
 /// Delete a slash command
 #[tauri::command]
-pub async fn slash_command_delete(command_id: String, project_path: Option<String>) -> Result<String, String> {
+pub async fn slash_command_delete(
+    command_id: String,
+    project_path: Option<String>,
+) -> Result<String, String> {
     info!("Deleting slash command: {}", command_id);
-    
+
     // First, we need to determine if this is a project command by parsing the ID
     let is_project_command = command_id.starts_with("project-");
-    
+
     // If it's a project command and we don't have a project path, error out
     if is_project_command && project_path.is_none() {
         return Err("Project path required to delete project commands".to_string());
     }
-    
+
     // List all commands (including project commands if applicable)
     let commands = slash_commands_list(project_path).await?;
-    
+
     // Find the command by ID
     let command = commands
         .into_iter()
         .find(|cmd| cmd.id == command_id)
         .ok_or_else(|| format!("Command not found: {}", command_id))?;
-    
+
     // Delete the file
     fs::remove_file(&command.file_path)
         .map_err(|e| format!("Failed to delete command file: {}", e))?;
-    
+
     // Clean up empty directories
     if let Some(parent) = Path::new(&command.file_path).parent() {
         let _ = remove_empty_dirs(parent);
     }
-    
+
     Ok(format!("Deleted command: {}", command.full_command))
 }
 
@@ -453,18 +454,18 @@ fn remove_empty_dirs(dir: &Path) -> Result<()> {
     if !dir.exists() {
         return Ok(());
     }
-    
+
     // Check if directory is empty
     let is_empty = fs::read_dir(dir)?.next().is_none();
-    
+
     if is_empty {
         fs::remove_dir(dir)?;
-        
+
         // Try to remove parent if it's also empty
         if let Some(parent) = dir.parent() {
             let _ = remove_empty_dirs(parent);
         }
     }
-    
+
     Ok(())
 }

--- a/src-tauri/src/process/registry.rs
+++ b/src-tauri/src/process/registry.rs
@@ -7,13 +7,8 @@ use tokio::process::Child;
 /// Type of process being tracked
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ProcessType {
-    AgentRun {
-        agent_id: i64,
-        agent_name: String,
-    },
-    ClaudeSession {
-        session_id: String,
-    },
+    AgentRun { agent_id: i64, agent_name: String },
+    ClaudeSession { session_id: String },
 }
 
 /// Information about a running agent process
@@ -72,7 +67,10 @@ impl ProcessRegistry {
     ) -> Result<(), String> {
         let process_info = ProcessInfo {
             run_id,
-            process_type: ProcessType::AgentRun { agent_id, agent_name },
+            process_type: ProcessType::AgentRun {
+                agent_id,
+                agent_name,
+            },
             pid,
             started_at: Utc::now(),
             project_path,
@@ -96,7 +94,10 @@ impl ProcessRegistry {
     ) -> Result<(), String> {
         let process_info = ProcessInfo {
             run_id,
-            process_type: ProcessType::AgentRun { agent_id, agent_name },
+            process_type: ProcessType::AgentRun {
+                agent_id,
+                agent_name,
+            },
             pid,
             started_at: Utc::now(),
             project_path,
@@ -106,7 +107,7 @@ impl ProcessRegistry {
 
         // For sidecar processes, we register without the child handle since it's managed differently
         let mut processes = self.processes.lock().map_err(|e| e.to_string())?;
-        
+
         let process_handle = ProcessHandle {
             info: process_info,
             child: Arc::new(Mutex::new(None)), // No tokio::process::Child handle for sidecar
@@ -127,7 +128,7 @@ impl ProcessRegistry {
         model: String,
     ) -> Result<i64, String> {
         let run_id = self.generate_id()?;
-        
+
         let process_info = ProcessInfo {
             run_id,
             process_type: ProcessType::ClaudeSession { session_id },
@@ -140,7 +141,7 @@ impl ProcessRegistry {
 
         // Register without child - Claude sessions use ClaudeProcessState for process management
         let mut processes = self.processes.lock().map_err(|e| e.to_string())?;
-        
+
         let process_handle = ProcessHandle {
             info: process_info,
             child: Arc::new(Mutex::new(None)), // No child handle for Claude sessions
@@ -175,25 +176,24 @@ impl ProcessRegistry {
         let processes = self.processes.lock().map_err(|e| e.to_string())?;
         Ok(processes
             .values()
-            .filter_map(|handle| {
-                match &handle.info.process_type {
-                    ProcessType::ClaudeSession { .. } => Some(handle.info.clone()),
-                    _ => None,
-                }
+            .filter_map(|handle| match &handle.info.process_type {
+                ProcessType::ClaudeSession { .. } => Some(handle.info.clone()),
+                _ => None,
             })
             .collect())
     }
 
     /// Get a specific Claude session by session ID
-    pub fn get_claude_session_by_id(&self, session_id: &str) -> Result<Option<ProcessInfo>, String> {
+    pub fn get_claude_session_by_id(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<ProcessInfo>, String> {
         let processes = self.processes.lock().map_err(|e| e.to_string())?;
         Ok(processes
             .values()
-            .find(|handle| {
-                match &handle.info.process_type {
-                    ProcessType::ClaudeSession { session_id: sid } => sid == session_id,
-                    _ => false,
-                }
+            .find(|handle| match &handle.info.process_type {
+                ProcessType::ClaudeSession { session_id: sid } => sid == session_id,
+                _ => false,
             })
             .map(|handle| handle.info.clone()))
     }
@@ -221,11 +221,9 @@ impl ProcessRegistry {
         let processes = self.processes.lock().map_err(|e| e.to_string())?;
         Ok(processes
             .values()
-            .filter_map(|handle| {
-                match &handle.info.process_type {
-                    ProcessType::AgentRun { .. } => Some(handle.info.clone()),
-                    _ => None,
-                }
+            .filter_map(|handle| match &handle.info.process_type {
+                ProcessType::AgentRun { .. } => Some(handle.info.clone()),
+                _ => None,
             })
             .collect())
     }
@@ -273,17 +271,26 @@ impl ProcessRegistry {
                     }
                 }
             } else {
-                warn!("No child handle available for process {} (PID: {}), attempting system kill", run_id, pid);
+                warn!(
+                    "No child handle available for process {} (PID: {}), attempting system kill",
+                    run_id, pid
+                );
                 false // Process handle not available, try fallback
             }
         };
 
         // If direct kill didn't work, try system command as fallback
         if !kill_sent {
-            info!("Attempting fallback kill for process {} (PID: {})", run_id, pid);
+            info!(
+                "Attempting fallback kill for process {} (PID: {})",
+                run_id, pid
+            );
             match self.kill_process_by_pid(run_id, pid) {
                 Ok(true) => return Ok(true),
-                Ok(false) => warn!("Fallback kill also failed for process {} (PID: {})", run_id, pid),
+                Ok(false) => warn!(
+                    "Fallback kill also failed for process {} (PID: {})",
+                    run_id, pid
+                ),
                 Err(e) => error!("Error during fallback kill: {}", e),
             }
             // Continue with the rest of the cleanup even if fallback failed

--- a/src-tauri/src/web_main.rs
+++ b/src-tauri/src/web_main.rs
@@ -1,8 +1,8 @@
 use clap::Parser;
 
-mod commands;
 mod checkpoint;
 mod claude_binary;
+mod commands;
 mod process;
 mod web_server;
 
@@ -13,7 +13,7 @@ struct Args {
     /// Port to run the web server on
     #[arg(short, long, default_value = "8080")]
     port: u16,
-    
+
     /// Host to bind to (0.0.0.0 for all interfaces)
     #[arg(short = 'H', long, default_value = "0.0.0.0")]
     host: String,
@@ -22,12 +22,15 @@ struct Args {
 #[tokio::main]
 async fn main() {
     env_logger::init();
-    
+
     let args = Args::parse();
-    
+
     println!("🚀 Starting Opcode Web Server...");
-    println!("📱 Will be accessible from phones at: http://{}:{}", args.host, args.port);
-    
+    println!(
+        "📱 Will be accessible from phones at: http://{}:{}",
+        args.host, args.port
+    );
+
     if let Err(e) = web_server::start_web_mode(Some(args.port)).await {
         eprintln!("❌ Failed to start web server: {}", e);
         std::process::exit(1);

--- a/src-tauri/src/web_server.rs
+++ b/src-tauri/src/web_server.rs
@@ -1,21 +1,21 @@
-use std::net::SocketAddr;
-use std::sync::Arc;
+use axum::extract::ws::{Message, WebSocket};
+use axum::http::Method;
 use axum::{
-    extract::{Path, WebSocketUpgrade, State as AxumState},
+    extract::{Path, State as AxumState, WebSocketUpgrade},
     response::{Html, Json, Response},
     routing::get,
     Router,
 };
-use axum::http::Method;
-use axum::extract::ws::{WebSocket, Message};
-use tower_http::cors::{CorsLayer, Any};
-use tower_http::services::ServeDir;
+use chrono;
+use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use chrono;
+use std::net::SocketAddr;
+use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::sync::Mutex;
-use futures_util::{SinkExt, StreamExt};
+use tower_http::cors::{Any, CorsLayer};
+use tower_http::services::ServeDir;
 use which;
 
 use crate::commands;
@@ -25,35 +25,45 @@ fn find_claude_binary_web() -> Result<String, String> {
     // First try the bundled binary (same location as Tauri app uses)
     let bundled_binary = "src-tauri/binaries/claude-code-x86_64-unknown-linux-gnu";
     if std::path::Path::new(bundled_binary).exists() {
-        println!("[find_claude_binary_web] Using bundled binary: {}", bundled_binary);
+        println!(
+            "[find_claude_binary_web] Using bundled binary: {}",
+            bundled_binary
+        );
         return Ok(bundled_binary.to_string());
     }
-    
+
     // Fall back to system installation paths
-    let home_path = format!("{}/.local/bin/claude", std::env::var("HOME").unwrap_or_default());
+    let home_path = format!(
+        "{}/.local/bin/claude",
+        std::env::var("HOME").unwrap_or_default()
+    );
     let candidates = vec![
         "claude",
-        "claude-code", 
+        "claude-code",
         "/usr/local/bin/claude",
         "/usr/bin/claude",
         "/opt/homebrew/bin/claude",
         &home_path,
     ];
-    
+
     for candidate in candidates {
         if which::which(candidate).is_ok() {
-            println!("[find_claude_binary_web] Using system binary: {}", candidate);
+            println!(
+                "[find_claude_binary_web] Using system binary: {}",
+                candidate
+            );
             return Ok(candidate.to_string());
         }
     }
-    
+
     Err("Claude binary not found in bundled location or system paths".to_string())
 }
 
 #[derive(Clone)]
 pub struct AppState {
     // Track active WebSocket sessions for Claude execution
-    pub active_sessions: Arc<Mutex<std::collections::HashMap<String, tokio::sync::mpsc::Sender<String>>>>,
+    pub active_sessions:
+        Arc<Mutex<std::collections::HashMap<String, tokio::sync::mpsc::Sender<String>>>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -110,7 +120,9 @@ async fn get_projects() -> Json<ApiResponse<Vec<commands::claude::Project>>> {
 }
 
 /// API endpoint to get sessions for a project
-async fn get_sessions(Path(project_id): Path<String>) -> Json<ApiResponse<Vec<commands::claude::Session>>> {
+async fn get_sessions(
+    Path(project_id): Path<String>,
+) -> Json<ApiResponse<Vec<commands::claude::Session>>> {
     match commands::claude::get_project_sessions(project_id).await {
         Ok(sessions) => Json(ApiResponse::success(sessions)),
         Err(e) => Json(ApiResponse::error(e.to_string())),
@@ -152,11 +164,14 @@ async fn check_claude_version() -> Json<ApiResponse<serde_json::Value>> {
 }
 
 /// List all available Claude installations on the system
-async fn list_claude_installations() -> Json<ApiResponse<Vec<crate::claude_binary::ClaudeInstallation>>> {
+async fn list_claude_installations(
+) -> Json<ApiResponse<Vec<crate::claude_binary::ClaudeInstallation>>> {
     let installations = crate::claude_binary::discover_claude_installations();
 
     if installations.is_empty() {
-        Json(ApiResponse::error("No Claude Code installations found on the system".to_string()))
+        Json(ApiResponse::error(
+            "No Claude Code installations found on the system".to_string(),
+        ))
     } else {
         Json(ApiResponse::success(installations))
     }
@@ -164,7 +179,9 @@ async fn list_claude_installations() -> Json<ApiResponse<Vec<crate::claude_binar
 
 /// Get system prompt - return default for web mode
 async fn get_system_prompt() -> Json<ApiResponse<String>> {
-    let default_prompt = "You are Claude, an AI assistant created by Anthropic. You are running in web server mode.".to_string();
+    let default_prompt =
+        "You are Claude, an AI assistant created by Anthropic. You are running in web server mode."
+            .to_string();
     Json(ApiResponse::success(default_prompt))
 }
 
@@ -185,7 +202,9 @@ async fn mcp_list() -> Json<ApiResponse<Vec<serde_json::Value>>> {
 }
 
 /// Load session history from JSONL file
-async fn load_session_history(Path((session_id, project_id)): Path<(String, String)>) -> Json<ApiResponse<Vec<serde_json::Value>>> {
+async fn load_session_history(
+    Path((session_id, project_id)): Path<(String, String)>,
+) -> Json<ApiResponse<Vec<serde_json::Value>>> {
     match commands::claude::load_session_history(session_id, project_id).await {
         Ok(history) => Json(ApiResponse::success(history)),
         Err(e) => Json(ApiResponse::error(e.to_string())),
@@ -225,37 +244,45 @@ async fn cancel_claude_execution(Path(sessionId): Path<String>) -> Json<ApiRespo
 async fn get_claude_session_output(Path(sessionId): Path<String>) -> Json<ApiResponse<String>> {
     // In web mode, output is streamed via WebSocket, not stored
     println!("[TRACE] Output request for session: {}", sessionId);
-    Json(ApiResponse::success("Output available via WebSocket only".to_string()))
+    Json(ApiResponse::success(
+        "Output available via WebSocket only".to_string(),
+    ))
 }
 
 /// WebSocket handler for Claude execution with streaming output
-async fn claude_websocket(
-    ws: WebSocketUpgrade,
-    AxumState(state): AxumState<AppState>,
-) -> Response {
+async fn claude_websocket(ws: WebSocketUpgrade, AxumState(state): AxumState<AppState>) -> Response {
     ws.on_upgrade(move |socket| claude_websocket_handler(socket, state))
 }
 
 async fn claude_websocket_handler(socket: WebSocket, state: AppState) {
     let (mut sender, mut receiver) = socket.split();
     let session_id = uuid::Uuid::new_v4().to_string();
-    
-    println!("[TRACE] WebSocket handler started - session_id: {}", session_id);
-    
+
+    println!(
+        "[TRACE] WebSocket handler started - session_id: {}",
+        session_id
+    );
+
     // Channel for sending output to WebSocket
     let (tx, mut rx) = tokio::sync::mpsc::channel::<String>(100);
-    
+
     // Store session in state
     {
         let mut sessions = state.active_sessions.lock().await;
         sessions.insert(session_id.clone(), tx);
-        println!("[TRACE] Session stored in state - active sessions count: {}", sessions.len());
+        println!(
+            "[TRACE] Session stored in state - active sessions count: {}",
+            sessions.len()
+        );
     }
-    
+
     // Task to forward channel messages to WebSocket
     let session_id_for_forward = session_id.clone();
     let forward_task = tokio::spawn(async move {
-        println!("[TRACE] Forward task started for session {}", session_id_for_forward);
+        println!(
+            "[TRACE] Forward task started for session {}",
+            session_id_for_forward
+        );
         while let Some(message) = rx.recv().await {
             println!("[TRACE] Forwarding message to WebSocket: {}", message);
             if sender.send(Message::Text(message.into())).await.is_err() {
@@ -263,16 +290,22 @@ async fn claude_websocket_handler(socket: WebSocket, state: AppState) {
                 break;
             }
         }
-        println!("[TRACE] Forward task ended for session {}", session_id_for_forward);
+        println!(
+            "[TRACE] Forward task ended for session {}",
+            session_id_for_forward
+        );
     });
-    
+
     // Handle incoming messages from WebSocket
     println!("[TRACE] Starting to listen for WebSocket messages");
     while let Some(msg) = receiver.next().await {
         println!("[TRACE] Received WebSocket message: {:?}", msg);
         if let Ok(msg) = msg {
             if let Message::Text(text) = msg {
-                println!("[TRACE] WebSocket text message received - length: {} chars", text.len());
+                println!(
+                    "[TRACE] WebSocket text message received - length: {} chars",
+                    text.len()
+                );
                 println!("[TRACE] WebSocket message content: {}", text);
                 match serde_json::from_str::<ClaudeExecutionRequest>(&text) {
                     Ok(request) => {
@@ -280,84 +313,102 @@ async fn claude_websocket_handler(socket: WebSocket, state: AppState) {
                         println!("[TRACE] Command type: {}", request.command_type);
                         println!("[TRACE] Project path: {}", request.project_path);
                         println!("[TRACE] Prompt length: {} chars", request.prompt.len());
-                        
+
                         // Execute Claude command based on request type
                         let session_id_clone = session_id.clone();
                         let state_clone = state.clone();
-                        
-                        println!("[TRACE] Spawning task to execute command: {}", request.command_type);
+
+                        println!(
+                            "[TRACE] Spawning task to execute command: {}",
+                            request.command_type
+                        );
                         tokio::spawn(async move {
-                        println!("[TRACE] Task started for command execution");
-                        let result = match request.command_type.as_str() {
-                            "execute" => {
-                                println!("[TRACE] Calling execute_claude_command");
-                                execute_claude_command(
-                                    request.project_path,
-                                    request.prompt,
-                                    request.model.unwrap_or_default(),
-                                    session_id_clone.clone(),
-                                    state_clone.clone(),
-                                ).await
-                            },
-                            "continue" => {
-                                println!("[TRACE] Calling continue_claude_command");
-                                continue_claude_command(
-                                    request.project_path,
-                                    request.prompt,
-                                    request.model.unwrap_or_default(),
-                                    session_id_clone.clone(),
-                                    state_clone.clone(),
-                                ).await
-                            },
-                            "resume" => {
-                                println!("[TRACE] Calling resume_claude_command");
-                                resume_claude_command(
-                                    request.project_path,
-                                    request.session_id.unwrap_or_default(),
-                                    request.prompt,
-                                    request.model.unwrap_or_default(),
-                                    session_id_clone.clone(),
-                                    state_clone.clone(),
-                                ).await
-                            },
-                            _ => {
-                                println!("[TRACE] Unknown command type: {}", request.command_type);
-                                Err("Unknown command type".to_string())
-                            },
-                        };
-                        
-                        println!("[TRACE] Command execution finished with result: {:?}", result);
-                        
-                        // Send completion message
-                        if let Some(sender) = state_clone.active_sessions.lock().await.get(&session_id_clone) {
-                            let completion_msg = match result {
-                                Ok(_) => json!({
-                                    "type": "completion",
-                                    "status": "success"
-                                }),
-                                Err(e) => json!({
-                                    "type": "completion",
-                                    "status": "error",
-                                    "error": e
-                                }),
+                            println!("[TRACE] Task started for command execution");
+                            let result = match request.command_type.as_str() {
+                                "execute" => {
+                                    println!("[TRACE] Calling execute_claude_command");
+                                    execute_claude_command(
+                                        request.project_path,
+                                        request.prompt,
+                                        request.model.unwrap_or_default(),
+                                        session_id_clone.clone(),
+                                        state_clone.clone(),
+                                    )
+                                    .await
+                                }
+                                "continue" => {
+                                    println!("[TRACE] Calling continue_claude_command");
+                                    continue_claude_command(
+                                        request.project_path,
+                                        request.prompt,
+                                        request.model.unwrap_or_default(),
+                                        session_id_clone.clone(),
+                                        state_clone.clone(),
+                                    )
+                                    .await
+                                }
+                                "resume" => {
+                                    println!("[TRACE] Calling resume_claude_command");
+                                    resume_claude_command(
+                                        request.project_path,
+                                        request.session_id.unwrap_or_default(),
+                                        request.prompt,
+                                        request.model.unwrap_or_default(),
+                                        session_id_clone.clone(),
+                                        state_clone.clone(),
+                                    )
+                                    .await
+                                }
+                                _ => {
+                                    println!(
+                                        "[TRACE] Unknown command type: {}",
+                                        request.command_type
+                                    );
+                                    Err("Unknown command type".to_string())
+                                }
                             };
-                            println!("[TRACE] Sending completion message: {}", completion_msg);
-                            let _ = sender.send(completion_msg.to_string()).await;
-                        } else {
-                            println!("[TRACE] Session not found in active sessions when sending completion");
-                        }
-                    });
+
+                            println!(
+                                "[TRACE] Command execution finished with result: {:?}",
+                                result
+                            );
+
+                            // Send completion message
+                            if let Some(sender) = state_clone
+                                .active_sessions
+                                .lock()
+                                .await
+                                .get(&session_id_clone)
+                            {
+                                let completion_msg = match result {
+                                    Ok(_) => json!({
+                                        "type": "completion",
+                                        "status": "success"
+                                    }),
+                                    Err(e) => json!({
+                                        "type": "completion",
+                                        "status": "error",
+                                        "error": e
+                                    }),
+                                };
+                                println!("[TRACE] Sending completion message: {}", completion_msg);
+                                let _ = sender.send(completion_msg.to_string()).await;
+                            } else {
+                                println!("[TRACE] Session not found in active sessions when sending completion");
+                            }
+                        });
                     }
                     Err(e) => {
                         println!("[TRACE] Failed to parse WebSocket request: {}", e);
                         println!("[TRACE] Raw message that failed to parse: {}", text);
-                        
+
                         // Send error back to client
                         let error_msg = json!({
                             "type": "error",
                             "message": format!("Failed to parse request: {}", e)
                         });
-                        if let Some(sender_tx) = state.active_sessions.lock().await.get(&session_id) {
+                        if let Some(sender_tx) = state.active_sessions.lock().await.get(&session_id)
+                        {
                             let _ = sender_tx.send(error_msg.to_string()).await;
                         }
                     }
@@ -372,16 +423,20 @@ async fn claude_websocket_handler(socket: WebSocket, state: AppState) {
             println!("[TRACE] Error receiving WebSocket message");
         }
     }
-    
+
     println!("[TRACE] WebSocket message loop ended");
-    
+
     // Clean up session
     {
         let mut sessions = state.active_sessions.lock().await;
         sessions.remove(&session_id);
-        println!("[TRACE] Session {} removed from state - remaining sessions: {}", session_id, sessions.len());
+        println!(
+            "[TRACE] Session {} removed from state - remaining sessions: {}",
+            session_id,
+            sessions.len()
+        );
     }
-    
+
     forward_task.abort();
     println!("[TRACE] WebSocket handler ended for session {}", session_id);
 }
@@ -394,22 +449,28 @@ async fn execute_claude_command(
     session_id: String,
     state: AppState,
 ) -> Result<(), String> {
-    use tokio::process::Command;
     use tokio::io::{AsyncBufReadExt, BufReader};
-    
+    use tokio::process::Command;
+
     println!("[TRACE] execute_claude_command called:");
     println!("[TRACE]   project_path: {}", project_path);
     println!("[TRACE]   prompt length: {} chars", prompt.len());
     println!("[TRACE]   model: {}", model);
     println!("[TRACE]   session_id: {}", session_id);
-    
+
     // Send initial message
     println!("[TRACE] Sending initial start message");
-    send_to_session(&state, &session_id, json!({
-        "type": "start",
-        "message": "Starting Claude execution..."
-    }).to_string()).await;
-    
+    send_to_session(
+        &state,
+        &session_id,
+        json!({
+            "type": "start",
+            "message": "Starting Claude execution..."
+        })
+        .to_string(),
+    )
+    .await;
+
     // Find Claude binary (simplified for web mode)
     println!("[TRACE] Finding Claude binary...");
     let claude_path = find_claude_binary_web().map_err(|e| {
@@ -418,24 +479,30 @@ async fn execute_claude_command(
         error
     })?;
     println!("[TRACE] Found Claude binary: {}", claude_path);
-    
+
     // Create Claude command
     println!("[TRACE] Creating Claude command...");
     let mut cmd = Command::new(&claude_path);
     let args = [
-        "-p", &prompt,
-        "--model", &model,
-        "--output-format", "stream-json",
+        "-p",
+        &prompt,
+        "--model",
+        &model,
+        "--output-format",
+        "stream-json",
         "--verbose",
-        "--dangerously-skip-permissions"
+        "--dangerously-skip-permissions",
     ];
     cmd.args(args);
     cmd.current_dir(&project_path);
     cmd.stdout(std::process::Stdio::piped());
     cmd.stderr(std::process::Stdio::piped());
-    
-    println!("[TRACE] Command: {} {:?} (in dir: {})", claude_path, args, project_path);
-    
+
+    println!(
+        "[TRACE] Command: {} {:?} (in dir: {})",
+        claude_path, args, project_path
+    );
+
     // Spawn Claude process
     println!("[TRACE] Spawning Claude process...");
     let mut child = cmd.spawn().map_err(|e| {
@@ -444,14 +511,14 @@ async fn execute_claude_command(
         error
     })?;
     println!("[TRACE] Claude process spawned successfully");
-    
+
     // Get stdout for streaming
     let stdout = child.stdout.take().ok_or_else(|| {
         println!("[TRACE] Failed to get stdout from child process");
         "Failed to get stdout".to_string()
     })?;
     let stdout_reader = BufReader::new(stdout);
-    
+
     println!("[TRACE] Starting to read Claude output...");
     // Stream output line by line
     let mut lines = stdout_reader.lines();
@@ -459,18 +526,22 @@ async fn execute_claude_command(
     while let Ok(Some(line)) = lines.next_line().await {
         line_count += 1;
         println!("[TRACE] Claude output line {}: {}", line_count, line);
-        
+
         // Send each line to WebSocket
         let message = json!({
             "type": "output",
             "content": line
-        }).to_string();
+        })
+        .to_string();
         println!("[TRACE] Sending output message to session: {}", message);
         send_to_session(&state, &session_id, message).await;
     }
-    
-    println!("[TRACE] Finished reading Claude output ({} lines total)", line_count);
-    
+
+    println!(
+        "[TRACE] Finished reading Claude output ({} lines total)",
+        line_count
+    );
+
     // Wait for process to complete
     println!("[TRACE] Waiting for Claude process to complete...");
     let exit_status = child.wait().await.map_err(|e| {
@@ -478,15 +549,21 @@ async fn execute_claude_command(
         println!("[TRACE] Wait error: {}", error);
         error
     })?;
-    
-    println!("[TRACE] Claude process completed with status: {:?}", exit_status);
-    
+
+    println!(
+        "[TRACE] Claude process completed with status: {:?}",
+        exit_status
+    );
+
     if !exit_status.success() {
-        let error = format!("Claude execution failed with exit code: {:?}", exit_status.code());
+        let error = format!(
+            "Claude execution failed with exit code: {:?}",
+            exit_status.code()
+        );
         println!("[TRACE] Claude execution failed: {}", error);
         return Err(error);
     }
-    
+
     println!("[TRACE] execute_claude_command completed successfully");
     Ok(())
 }
@@ -498,49 +575,73 @@ async fn continue_claude_command(
     session_id: String,
     state: AppState,
 ) -> Result<(), String> {
-    use tokio::process::Command;
     use tokio::io::{AsyncBufReadExt, BufReader};
-    
-    send_to_session(&state, &session_id, json!({
-        "type": "start",
-        "message": "Continuing Claude session..."
-    }).to_string()).await;
-    
+    use tokio::process::Command;
+
+    send_to_session(
+        &state,
+        &session_id,
+        json!({
+            "type": "start",
+            "message": "Continuing Claude session..."
+        })
+        .to_string(),
+    )
+    .await;
+
     // Find Claude binary
-    let claude_path = find_claude_binary_web().map_err(|e| format!("Claude binary not found: {}", e))?;
-    
+    let claude_path =
+        find_claude_binary_web().map_err(|e| format!("Claude binary not found: {}", e))?;
+
     // Create continue command
     let mut cmd = Command::new(&claude_path);
     cmd.args([
         "-c", // Continue flag
-        "-p", &prompt,
-        "--model", &model,
-        "--output-format", "stream-json",
+        "-p",
+        &prompt,
+        "--model",
+        &model,
+        "--output-format",
+        "stream-json",
         "--verbose",
-        "--dangerously-skip-permissions"
+        "--dangerously-skip-permissions",
     ]);
     cmd.current_dir(&project_path);
     cmd.stdout(std::process::Stdio::piped());
     cmd.stderr(std::process::Stdio::piped());
-    
+
     // Spawn and stream output
-    let mut child = cmd.spawn().map_err(|e| format!("Failed to spawn Claude: {}", e))?;
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| format!("Failed to spawn Claude: {}", e))?;
     let stdout = child.stdout.take().ok_or("Failed to get stdout")?;
     let stdout_reader = BufReader::new(stdout);
-    
+
     let mut lines = stdout_reader.lines();
     while let Ok(Some(line)) = lines.next_line().await {
-        send_to_session(&state, &session_id, json!({
-            "type": "output",
-            "content": line
-        }).to_string()).await;
+        send_to_session(
+            &state,
+            &session_id,
+            json!({
+                "type": "output",
+                "content": line
+            })
+            .to_string(),
+        )
+        .await;
     }
-    
-    let exit_status = child.wait().await.map_err(|e| format!("Failed to wait for Claude: {}", e))?;
+
+    let exit_status = child
+        .wait()
+        .await
+        .map_err(|e| format!("Failed to wait for Claude: {}", e))?;
     if !exit_status.success() {
-        return Err(format!("Claude execution failed with exit code: {:?}", exit_status.code()));
+        return Err(format!(
+            "Claude execution failed with exit code: {:?}",
+            exit_status.code()
+        ));
     }
-    
+
     Ok(())
 }
 
@@ -552,40 +653,57 @@ async fn resume_claude_command(
     session_id: String,
     state: AppState,
 ) -> Result<(), String> {
-    use tokio::process::Command;
     use tokio::io::{AsyncBufReadExt, BufReader};
-    
+    use tokio::process::Command;
+
     println!("[resume_claude_command] Starting with project_path: {}, claude_session_id: {}, prompt: {}, model: {}", 
              project_path, claude_session_id, prompt, model);
-    
-    send_to_session(&state, &session_id, json!({
-        "type": "start",
-        "message": "Resuming Claude session..."
-    }).to_string()).await;
-    
+
+    send_to_session(
+        &state,
+        &session_id,
+        json!({
+            "type": "start",
+            "message": "Resuming Claude session..."
+        })
+        .to_string(),
+    )
+    .await;
+
     // Find Claude binary
     println!("[resume_claude_command] Finding Claude binary...");
-    let claude_path = find_claude_binary_web().map_err(|e| format!("Claude binary not found: {}", e))?;
-    println!("[resume_claude_command] Found Claude binary: {}", claude_path);
-    
+    let claude_path =
+        find_claude_binary_web().map_err(|e| format!("Claude binary not found: {}", e))?;
+    println!(
+        "[resume_claude_command] Found Claude binary: {}",
+        claude_path
+    );
+
     // Create resume command
     println!("[resume_claude_command] Creating command...");
     let mut cmd = Command::new(&claude_path);
     let args = [
-        "--resume", &claude_session_id,
-        "-p", &prompt,
-        "--model", &model,
-        "--output-format", "stream-json",
+        "--resume",
+        &claude_session_id,
+        "-p",
+        &prompt,
+        "--model",
+        &model,
+        "--output-format",
+        "stream-json",
         "--verbose",
-        "--dangerously-skip-permissions"
+        "--dangerously-skip-permissions",
     ];
     cmd.args(args);
     cmd.current_dir(&project_path);
     cmd.stdout(std::process::Stdio::piped());
     cmd.stderr(std::process::Stdio::piped());
-    
-    println!("[resume_claude_command] Command: {} {:?} (in dir: {})", claude_path, args, project_path);
-    
+
+    println!(
+        "[resume_claude_command] Command: {} {:?} (in dir: {})",
+        claude_path, args, project_path
+    );
+
     // Spawn and stream output
     println!("[resume_claude_command] Spawning process...");
     let mut child = cmd.spawn().map_err(|e| {
@@ -596,27 +714,39 @@ async fn resume_claude_command(
     println!("[resume_claude_command] Process spawned successfully");
     let stdout = child.stdout.take().ok_or("Failed to get stdout")?;
     let stdout_reader = BufReader::new(stdout);
-    
+
     let mut lines = stdout_reader.lines();
     while let Ok(Some(line)) = lines.next_line().await {
-        send_to_session(&state, &session_id, json!({
-            "type": "output",
-            "content": line
-        }).to_string()).await;
+        send_to_session(
+            &state,
+            &session_id,
+            json!({
+                "type": "output",
+                "content": line
+            })
+            .to_string(),
+        )
+        .await;
     }
-    
-    let exit_status = child.wait().await.map_err(|e| format!("Failed to wait for Claude: {}", e))?;
+
+    let exit_status = child
+        .wait()
+        .await
+        .map_err(|e| format!("Failed to wait for Claude: {}", e))?;
     if !exit_status.success() {
-        return Err(format!("Claude execution failed with exit code: {:?}", exit_status.code()));
+        return Err(format!(
+            "Claude execution failed with exit code: {:?}",
+            exit_status.code()
+        ));
     }
-    
+
     Ok(())
 }
 
 async fn send_to_session(state: &AppState, session_id: &str, message: String) {
     println!("[TRACE] send_to_session called for session: {}", session_id);
     println!("[TRACE] Message: {}", message);
-    
+
     let sessions = state.active_sessions.lock().await;
     if let Some(sender) = sessions.get(session_id) {
         println!("[TRACE] Found session in active sessions, sending message...");
@@ -625,8 +755,14 @@ async fn send_to_session(state: &AppState, session_id: &str, message: String) {
             Err(e) => println!("[TRACE] Failed to send message: {}", e),
         }
     } else {
-        println!("[TRACE] Session {} not found in active sessions", session_id);
-        println!("[TRACE] Active sessions: {:?}", sessions.keys().collect::<Vec<_>>());
+        println!(
+            "[TRACE] Session {} not found in active sessions",
+            session_id
+        );
+        println!(
+            "[TRACE] Active sessions: {:?}",
+            sessions.keys().collect::<Vec<_>>()
+        );
     }
 }
 
@@ -647,53 +783,55 @@ pub async fn create_web_server(port: u16) -> Result<(), Box<dyn std::error::Erro
         // Frontend routes
         .route("/", get(serve_frontend))
         .route("/index.html", get(serve_frontend))
-        
         // API routes (REST API equivalent of Tauri commands)
         .route("/api/projects", get(get_projects))
         .route("/api/projects/{project_id}/sessions", get(get_sessions))
         .route("/api/agents", get(get_agents))
         .route("/api/usage", get(get_usage))
-        
         // Settings and configuration
         .route("/api/settings/claude", get(get_claude_settings))
         .route("/api/settings/claude/version", get(check_claude_version))
-        .route("/api/settings/claude/installations", get(list_claude_installations))
+        .route(
+            "/api/settings/claude/installations",
+            get(list_claude_installations),
+        )
         .route("/api/settings/system-prompt", get(get_system_prompt))
-        
         // Session management
         .route("/api/sessions/new", get(open_new_session))
-        
         // Slash commands
         .route("/api/slash-commands", get(list_slash_commands))
-        
         // MCP
         .route("/api/mcp/servers", get(mcp_list))
-        
         // Session history
-        .route("/api/sessions/{session_id}/history/{project_id}", get(load_session_history))
+        .route(
+            "/api/sessions/{session_id}/history/{project_id}",
+            get(load_session_history),
+        )
         .route("/api/sessions/running", get(list_running_claude_sessions))
-        
         // Claude execution endpoints (read-only in web mode)
         .route("/api/sessions/execute", get(execute_claude_code))
         .route("/api/sessions/continue", get(continue_claude_code))
         .route("/api/sessions/resume", get(resume_claude_code))
-        .route("/api/sessions/{sessionId}/cancel", get(cancel_claude_execution))
-        .route("/api/sessions/{sessionId}/output", get(get_claude_session_output))
-        
+        .route(
+            "/api/sessions/{sessionId}/cancel",
+            get(cancel_claude_execution),
+        )
+        .route(
+            "/api/sessions/{sessionId}/output",
+            get(get_claude_session_output),
+        )
         // WebSocket endpoint for real-time Claude execution
         .route("/ws/claude", get(claude_websocket))
-        
         // Serve static assets
         .nest_service("/assets", ServeDir::new("../dist/assets"))
         .nest_service("/vite.svg", ServeDir::new("../dist/vite.svg"))
-        
         .layer(cors)
         .with_state(state);
 
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
     println!("🌐 Web server running on http://0.0.0.0:{}", port);
     println!("📱 Access from phone: http://YOUR_PC_IP:{}", port);
-    
+
     let listener = TcpListener::bind(addr).await?;
     axum::serve(listener, app).await?;
 
@@ -703,7 +841,7 @@ pub async fn create_web_server(port: u16) -> Result<(), Box<dyn std::error::Erro
 /// Start web server mode (alternative to Tauri GUI)
 pub async fn start_web_mode(port: Option<u16>) -> Result<(), Box<dyn std::error::Error>> {
     let port = port.unwrap_or(8080);
-    
+
     println!("🚀 Starting Opcode in web server mode...");
     create_web_server(port).await
 }

--- a/src/lib/apiAdapter.ts
+++ b/src/lib/apiAdapter.ts
@@ -284,7 +284,9 @@ export function getEnvironmentInfo() {
  */
 async function handleStreamingCommand<T>(command: string, params?: any): Promise<T> {
   return new Promise((resolve, reject) => {
-    const wsUrl = `ws://${window.location.host}/ws/claude`;
+    // Use wss:// for HTTPS connections (e.g., ngrok), ws:// for HTTP (localhost)
+    const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const wsUrl = `${wsProtocol}//${window.location.host}/ws/claude`;
     console.log(`[TRACE] handleStreamingCommand called:`);
     console.log(`[TRACE]   command: ${command}`);
     console.log(`[TRACE]   params:`, params);


### PR DESCRIPTION
## Summary
Fix WebSocket connection for HTTPS/ngrok access by automatically detecting the page protocol and using the appropriate WebSocket protocol.

See also https://github.com/winfunc/opcode/pull/216

## Changes
- **WebSocket protocol detection**: Automatically use `wss://` for HTTPS connections (e.g., ngrok) and `ws://` for HTTP connections (localhost)
- **Rust formatting**: Apply `cargo fmt` to fix code style issues across multiple files

## Problem
When accessing the web UI via ngrok (HTTPS), the Send button didn't work because browsers block insecure WebSocket connections (`ws://`) from secure pages.

## Solution
Modified `src/lib/apiAdapter.ts` to detect the page protocol and construct the WebSocket URL accordingly:
```typescript
const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
const wsUrl = `${wsProtocol}//${window.location.host}/ws/claude`;
```

## Test plan
- [✓] Test Send button on localhost (HTTP)
- [✓] Test Send button via ngrok (HTTPS)
- [✓] Verify WebSocket connection established correctly in both cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)