### PR TITLE
Fix: Linux Wayland/NVIDIA compatibility and Rust warnings

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,6 +5,7 @@ description = "GUI app and Toolkit for Claude Code"
 authors = ["mufeedvh", "123vviekr"]
 license = "AGPL-3.0"
 edition = "2021"
+default-run = "opcode"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -52,6 +52,22 @@ use tauri::Manager;
 use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial};
 
 fn main() {
+    // Apply Linux/Wayland workarounds for WebKitGTK GBM buffer issues (especially on NVIDIA)
+    // This must be done before any GTK/WebKit initialization
+    #[cfg(target_os = "linux")]
+    {
+        use std::env;
+        // Only apply fix for Wayland sessions where GBM buffer issues occur
+        let is_wayland = env::var("WAYLAND_DISPLAY").is_ok()
+            || env::var("XDG_SESSION_TYPE")
+                .map(|v| v == "wayland")
+                .unwrap_or(false);
+
+        if is_wayland && env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
+            env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+        }
+    }
+
     // Initialize logger
     env_logger::init();
 

--- a/src-tauri/src/process/registry.rs
+++ b/src-tauri/src/process/registry.rs
@@ -82,6 +82,7 @@ impl ProcessRegistry {
     }
 
     /// Register a new running agent process using sidecar (similar to register_process but for sidecar children)
+    #[allow(dead_code)]
     pub fn register_sidecar_process(
         &self,
         run_id: i64,

--- a/src-tauri/src/web_server.rs
+++ b/src-tauri/src/web_server.rs
@@ -233,17 +233,17 @@ async fn resume_claude_code() -> Json<ApiResponse<serde_json::Value>> {
 }
 
 /// Cancel Claude execution
-async fn cancel_claude_execution(Path(sessionId): Path<String>) -> Json<ApiResponse<()>> {
+async fn cancel_claude_execution(Path(session_id): Path<String>) -> Json<ApiResponse<()>> {
     // In web mode, we don't have a way to cancel the subprocess cleanly
     // The WebSocket closing should handle cleanup
-    println!("[TRACE] Cancel request for session: {}", sessionId);
+    println!("[TRACE] Cancel request for session: {}", session_id);
     Json(ApiResponse::success(()))
 }
 
 /// Get Claude session output
-async fn get_claude_session_output(Path(sessionId): Path<String>) -> Json<ApiResponse<String>> {
+async fn get_claude_session_output(Path(session_id): Path<String>) -> Json<ApiResponse<String>> {
     // In web mode, output is streamed via WebSocket, not stored
-    println!("[TRACE] Output request for session: {}", sessionId);
+    println!("[TRACE] Output request for session: {}", session_id);
     Json(ApiResponse::success(
         "Output available via WebSocket only".to_string(),
     ))


### PR DESCRIPTION
## Problem

1. Running `bun run tauri dev` fails with error: `cargo run could not determine which binary to run`
2. On Linux with Wayland and NVIDIA GPU, app fails with: `Failed to create GBM buffer of size 800x600`
3. Rust compiler warnings for snake_case and dead_code

## Approach

1. Added `default-run = "opcode"` to `Cargo.toml` to specify the default binary
2. Added automatic detection and workaround for Wayland sessions in `main.rs`:
   - Detects Wayland via `WAYLAND_DISPLAY` or `XDG_SESSION_TYPE`
   - Only applies `WEBKIT_DISABLE_DMABUF_RENDERER=1` when needed
   - Respects user-defined environment variables
3. Fixed snake_case warnings: renamed `sessionId` to `session_id` in `web_server.rs`
4. Added `#[allow(dead_code)]` for `register_sidecar_process` (kept for future use)

## Limitations

- The Wayland/NVIDIA fix is a workaround for an upstream WebKitGTK issue, not a native fix
- Only affects Linux Wayland users; X11 users are unaffected

## Testing

- Tested on Arch Linux with KDE 6 (Wayland) and NVIDIA GPU
- Verified `bun run tauri dev` runs without errors
- Verified `cargo build` completes without warnings