### PR TITLE
feat: add multi-environment variable groups support

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,6 +5,7 @@ description = "GUI app and Toolkit for Claude Code"
 authors = ["mufeedvh", "123vviekr"]
 license = "AGPL-3.0"
 edition = "2021"
+default-run = "opcode"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/components/EnvGroupSelector.tsx
+++ b/src/components/EnvGroupSelector.tsx
@@ -1,0 +1,154 @@
+import React, { useState, useEffect } from "react";
+import { Layers, ChevronUp, Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Popover } from "@/components/ui/popover";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip-modern";
+import { api, type ClaudeSettings, type EnvGroup } from "@/lib/api";
+
+interface EnvGroupSelectorProps {
+  disabled?: boolean;
+}
+
+/**
+ * Environment Group Selector Component
+ * Allows users to quickly switch between different environment variable groups
+ */
+export const EnvGroupSelector: React.FC<EnvGroupSelectorProps> = ({
+  disabled = false,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [envGroups, setEnvGroups] = useState<Record<string, EnvGroup>>({});
+  const [activeGroupId, setActiveGroupId] = useState<string>("default");
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Load environment groups on mount
+  useEffect(() => {
+    const loadEnvGroups = async () => {
+      try {
+        setIsLoading(true);
+        const settings = await api.getClaudeSettings();
+
+        if (settings.envGroups && typeof settings.envGroups === "object") {
+          setEnvGroups(settings.envGroups);
+          setActiveGroupId(settings.activeEnvGroup || "default");
+        } else {
+          // Initialize with default group if none exist
+          const defaultGroup: EnvGroup = {
+            name: "Default",
+            variables: settings.env || {},
+          };
+          setEnvGroups({ default: defaultGroup });
+          setActiveGroupId("default");
+        }
+      } catch (error) {
+        console.error("Failed to load environment groups:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadEnvGroups();
+  }, []);
+
+  const handleSelectGroup = async (groupId: string) => {
+    try {
+      setActiveGroupId(groupId);
+      setIsOpen(false);
+
+      // Save the active group selection
+      const currentSettings = await api.getClaudeSettings();
+      const updatedSettings: ClaudeSettings = {
+        ...currentSettings,
+        activeEnvGroup: groupId,
+        // Also update the env field for backward compatibility
+        env: envGroups[groupId]?.variables || {},
+      };
+      await api.saveClaudeSettings(updatedSettings);
+    } catch (error) {
+      console.error("Failed to save active environment group:", error);
+    }
+  };
+
+  const activeGroup = envGroups[activeGroupId];
+  const groupCount = Object.keys(envGroups).length;
+  const varCount = activeGroup
+    ? Object.keys(activeGroup.variables || {}).length
+    : 0;
+
+  // Don't render if still loading or no groups
+  if (isLoading) {
+    return null;
+  }
+
+  return (
+    <Popover
+      trigger={
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={disabled}
+              className="h-9 px-2 hover:bg-accent/50 gap-1"
+            >
+              <Layers className="h-3.5 w-3.5 text-muted-foreground" />
+              <span className="text-[10px] font-semibold opacity-70 max-w-[60px] truncate">
+                {activeGroup?.name || "Default"}
+              </span>
+              <ChevronUp className="h-3 w-3 ml-0.5 opacity-50" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="top">
+            <p className="text-xs font-medium">
+              Environment: {activeGroup?.name || "Default"}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {varCount} variable{varCount !== 1 ? "s" : ""} • {groupCount}{" "}
+              group
+              {groupCount !== 1 ? "s" : ""}
+            </p>
+          </TooltipContent>
+        </Tooltip>
+      }
+      content={
+        <div className="w-[240px] p-1">
+          <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
+            Environment Groups
+          </div>
+          {Object.entries(envGroups).map(([groupId, group]) => (
+            <button
+              key={groupId}
+              onClick={() => handleSelectGroup(groupId)}
+              className={cn(
+                "w-full flex items-center gap-3 p-2.5 rounded-md transition-colors text-left",
+                "hover:bg-accent",
+                activeGroupId === groupId && "bg-accent"
+              )}
+            >
+              <Layers className="h-4 w-4 text-muted-foreground shrink-0" />
+              <div className="flex-1 min-w-0">
+                <div className="font-medium text-sm truncate">{group.name}</div>
+                <div className="text-xs text-muted-foreground">
+                  {Object.keys(group.variables || {}).length} variable
+                  {Object.keys(group.variables || {}).length !== 1 ? "s" : ""}
+                </div>
+              </div>
+              {activeGroupId === groupId && (
+                <Check className="h-4 w-4 text-primary shrink-0" />
+              )}
+            </button>
+          ))}
+        </div>
+      }
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      align="start"
+      side="top"
+    />
+  );
+};

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,13 +1,15 @@
 import React, { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { 
-  Plus, 
-  Trash2, 
-  Save, 
+import {
+  Plus,
+  Trash2,
+  Save,
   AlertCircle,
   Loader2,
   Shield,
   Check,
+  Layers,
+  Pencil,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -15,10 +17,11 @@ import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Card } from "@/components/ui/card";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-import { 
-  api, 
+import {
+  api,
   type ClaudeSettings,
-  type ClaudeInstallation
+  type ClaudeInstallation,
+  type EnvGroup,
 } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { Toast, ToastContainer } from "@/components/ui/toast";
@@ -57,46 +60,58 @@ interface EnvironmentVariable {
  * Comprehensive Settings UI for managing Claude Code settings
  * Provides a no-code interface for editing the settings.json file
  */
-export const Settings: React.FC<SettingsProps> = ({
-  className,
-}) => {
+export const Settings: React.FC<SettingsProps> = ({ className }) => {
   const [settings, setSettings] = useState<ClaudeSettings | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState("general");
-  const [currentBinaryPath, setCurrentBinaryPath] = useState<string | null>(null);
-  const [selectedInstallation, setSelectedInstallation] = useState<ClaudeInstallation | null>(null);
+  const [currentBinaryPath, setCurrentBinaryPath] = useState<string | null>(
+    null
+  );
+  const [selectedInstallation, setSelectedInstallation] =
+    useState<ClaudeInstallation | null>(null);
   const [binaryPathChanged, setBinaryPathChanged] = useState(false);
-  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
-  
+  const [toast, setToast] = useState<{
+    message: string;
+    type: "success" | "error";
+  } | null>(null);
+
   // Permission rules state
   const [allowRules, setAllowRules] = useState<PermissionRule[]>([]);
   const [denyRules, setDenyRules] = useState<PermissionRule[]>([]);
-  
+
   // Environment variables state
   const [envVars, setEnvVars] = useState<EnvironmentVariable[]>([]);
-  
+
+  // Environment variable groups state
+  const [envGroups, setEnvGroups] = useState<Record<string, EnvGroup>>({});
+  const [activeEnvGroupId, setActiveEnvGroupId] = useState<string>("default");
+  const [currentEditGroupId, setCurrentEditGroupId] =
+    useState<string>("default");
+  const [editingGroupName, setEditingGroupName] = useState<string | null>(null);
+  const [newGroupName, setNewGroupName] = useState<string>("");
+
   // Hooks state
   const [userHooksChanged, setUserHooksChanged] = useState(false);
   const getUserHooks = React.useRef<(() => any) | null>(null);
-  
+
   // Theme hook
   const { theme, setTheme, customColors, setCustomColors } = useTheme();
-  
+
   // Proxy state
   const [proxySettingsChanged, setProxySettingsChanged] = useState(false);
   const saveProxySettings = React.useRef<(() => Promise<void>) | null>(null);
-  
+
   // Analytics state
   const [analyticsEnabled, setAnalyticsEnabled] = useState(false);
   const trackEvent = useTrackEvent();
-  
+
   // Tab persistence state
   const [tabPersistenceEnabled, setTabPersistenceEnabled] = useState(true);
   // Startup intro preference
   const [startupIntroEnabled, setStartupIntroEnabled] = useState(true);
-  
+
   // Load settings on mount
   useEffect(() => {
     loadSettings();
@@ -106,8 +121,8 @@ export const Settings: React.FC<SettingsProps> = ({
     setTabPersistenceEnabled(TabPersistenceService.isEnabled());
     // Load startup intro setting (default to true if not set)
     (async () => {
-      const pref = await api.getSetting('startup_intro_enabled');
-      setStartupIntroEnabled(pref === null ? true : pref === 'true');
+      const pref = await api.getSetting("startup_intro_enabled");
+      setStartupIntroEnabled(pref === null ? true : pref === "true");
     })();
   }, []);
 
@@ -141,49 +156,105 @@ export const Settings: React.FC<SettingsProps> = ({
       setLoading(true);
       setError(null);
       const loadedSettings = await api.getClaudeSettings();
-      
+
       // Ensure loadedSettings is an object
-      if (!loadedSettings || typeof loadedSettings !== 'object') {
+      if (!loadedSettings || typeof loadedSettings !== "object") {
         console.warn("Loaded settings is not an object:", loadedSettings);
         setSettings({});
         return;
       }
-      
+
       setSettings(loadedSettings);
 
       // Parse permissions
-      if (loadedSettings.permissions && typeof loadedSettings.permissions === 'object') {
+      if (
+        loadedSettings.permissions &&
+        typeof loadedSettings.permissions === "object"
+      ) {
         if (Array.isArray(loadedSettings.permissions.allow)) {
           setAllowRules(
-            loadedSettings.permissions.allow.map((rule: string, index: number) => ({
-              id: `allow-${index}`,
-              value: rule,
-            }))
+            loadedSettings.permissions.allow.map(
+              (rule: string, index: number) => ({
+                id: `allow-${index}`,
+                value: rule,
+              })
+            )
           );
         }
         if (Array.isArray(loadedSettings.permissions.deny)) {
           setDenyRules(
-            loadedSettings.permissions.deny.map((rule: string, index: number) => ({
-              id: `deny-${index}`,
-              value: rule,
-            }))
+            loadedSettings.permissions.deny.map(
+              (rule: string, index: number) => ({
+                id: `deny-${index}`,
+                value: rule,
+              })
+            )
           );
         }
       }
 
-      // Parse environment variables
-      if (loadedSettings.env && typeof loadedSettings.env === 'object' && !Array.isArray(loadedSettings.env)) {
-        setEnvVars(
-          Object.entries(loadedSettings.env).map(([key, value], index) => ({
+      // Parse environment variables and groups
+      if (
+        loadedSettings.envGroups &&
+        typeof loadedSettings.envGroups === "object"
+      ) {
+        // Load environment variable groups
+        setEnvGroups(loadedSettings.envGroups);
+        const activeGroupId = loadedSettings.activeEnvGroup || "default";
+        setActiveEnvGroupId(activeGroupId);
+        setCurrentEditGroupId(activeGroupId);
+
+        // Load variables from the active group
+        const activeGroup = loadedSettings.envGroups[activeGroupId];
+        if (activeGroup && activeGroup.variables) {
+          setEnvVars(
+            Object.entries(activeGroup.variables).map(
+              ([key, value], index) => ({
+                id: `env-${index}`,
+                key,
+                value: value as string,
+              })
+            )
+          );
+        }
+      } else if (
+        loadedSettings.env &&
+        typeof loadedSettings.env === "object" &&
+        !Array.isArray(loadedSettings.env)
+      ) {
+        // Migrate from legacy env format to envGroups
+        const legacyEnvVars = Object.entries(loadedSettings.env).map(
+          ([key, value], index) => ({
             id: `env-${index}`,
             key,
             value: value as string,
-          }))
+          })
         );
+        setEnvVars(legacyEnvVars);
+
+        // Create default group from legacy env
+        const defaultGroup: EnvGroup = {
+          name: "Default",
+          variables: loadedSettings.env as Record<string, string>,
+        };
+        setEnvGroups({ default: defaultGroup });
+        setActiveEnvGroupId("default");
+        setCurrentEditGroupId("default");
+      } else {
+        // Initialize with empty default group
+        const defaultGroup: EnvGroup = {
+          name: "Default",
+          variables: {},
+        };
+        setEnvGroups({ default: defaultGroup });
+        setActiveEnvGroupId("default");
+        setCurrentEditGroupId("default");
       }
     } catch (err) {
       console.error("Failed to load settings:", err);
-      setError("Failed to load settings. Please ensure ~/.claude directory exists.");
+      setError(
+        "Failed to load settings. Please ensure ~/.claude directory exists."
+      );
       setSettings({});
     } finally {
       setLoading(false);
@@ -199,20 +270,48 @@ export const Settings: React.FC<SettingsProps> = ({
       setError(null);
       setToast(null);
 
+      // Build current edit group's variables from envVars
+      const currentGroupVariables = envVars.reduce((acc, { key, value }) => {
+        if (key && String(key).trim() && value && String(value).trim()) {
+          acc[key] = String(value);
+        }
+        return acc;
+      }, {} as Record<string, string>);
+
+      // Update the current edit group in envGroups
+      const updatedEnvGroups = {
+        ...envGroups,
+        [currentEditGroupId]: {
+          ...envGroups[currentEditGroupId],
+          variables: currentGroupVariables,
+        },
+      };
+
+      // Get active group variables for env field (backward compatibility)
+      const activeGroupVariables =
+        updatedEnvGroups[activeEnvGroupId]?.variables || {};
+
       // Build the settings object
       const updatedSettings: ClaudeSettings = {
         ...settings,
         permissions: {
-          allow: allowRules.map(rule => rule.value).filter(v => v && String(v).trim()),
-          deny: denyRules.map(rule => rule.value).filter(v => v && String(v).trim()),
+          allow: allowRules
+            .map((rule) => rule.value)
+            .filter((v) => v && String(v).trim()),
+          deny: denyRules
+            .map((rule) => rule.value)
+            .filter((v) => v && String(v).trim()),
         },
-        env: envVars.reduce((acc, { key, value }) => {
-          if (key && String(key).trim() && value && String(value).trim()) {
-            acc[key] = String(value);
-          }
-          return acc;
-        }, {} as Record<string, string>),
+        // Store active group's variables in env for backward compatibility
+        env: activeGroupVariables,
+        // Store all groups
+        envGroups: updatedEnvGroups,
+        // Store active group ID
+        activeEnvGroup: activeEnvGroupId,
       };
+
+      // Update local state with the new groups
+      setEnvGroups(updatedEnvGroups);
 
       await api.saveClaudeSettings(updatedSettings);
       setSettings(updatedSettings);
@@ -227,7 +326,7 @@ export const Settings: React.FC<SettingsProps> = ({
       // Save user hooks if changed
       if (userHooksChanged && getUserHooks.current) {
         const hooks = getUserHooks.current();
-        await api.updateHooksConfig('user', hooks);
+        await api.updateHooksConfig("user", hooks);
         setUserHooksChanged(false);
       }
 
@@ -251,7 +350,7 @@ export const Settings: React.FC<SettingsProps> = ({
    * Updates a simple setting value
    */
   const updateSetting = (key: string, value: any) => {
-    setSettings(prev => ({ ...prev, [key]: value }));
+    setSettings((prev) => ({ ...prev, [key]: value }));
   };
 
   /**
@@ -262,26 +361,30 @@ export const Settings: React.FC<SettingsProps> = ({
       id: `${type}-${Date.now()}`,
       value: "",
     };
-    
+
     if (type === "allow") {
-      setAllowRules(prev => [...prev, newRule]);
+      setAllowRules((prev) => [...prev, newRule]);
     } else {
-      setDenyRules(prev => [...prev, newRule]);
+      setDenyRules((prev) => [...prev, newRule]);
     }
   };
 
   /**
    * Updates a permission rule
    */
-  const updatePermissionRule = (type: "allow" | "deny", id: string, value: string) => {
+  const updatePermissionRule = (
+    type: "allow" | "deny",
+    id: string,
+    value: string
+  ) => {
     if (type === "allow") {
-      setAllowRules(prev => prev.map(rule => 
-        rule.id === id ? { ...rule, value } : rule
-      ));
+      setAllowRules((prev) =>
+        prev.map((rule) => (rule.id === id ? { ...rule, value } : rule))
+      );
     } else {
-      setDenyRules(prev => prev.map(rule => 
-        rule.id === id ? { ...rule, value } : rule
-      ));
+      setDenyRules((prev) =>
+        prev.map((rule) => (rule.id === id ? { ...rule, value } : rule))
+      );
     }
   };
 
@@ -290,9 +393,9 @@ export const Settings: React.FC<SettingsProps> = ({
    */
   const removePermissionRule = (type: "allow" | "deny", id: string) => {
     if (type === "allow") {
-      setAllowRules(prev => prev.filter(rule => rule.id !== id));
+      setAllowRules((prev) => prev.filter((rule) => rule.id !== id));
     } else {
-      setDenyRules(prev => prev.filter(rule => rule.id !== id));
+      setDenyRules((prev) => prev.filter((rule) => rule.id !== id));
     }
   };
 
@@ -305,23 +408,112 @@ export const Settings: React.FC<SettingsProps> = ({
       key: "",
       value: "",
     };
-    setEnvVars(prev => [...prev, newVar]);
+    setEnvVars((prev) => [...prev, newVar]);
   };
 
   /**
    * Updates an environment variable
    */
   const updateEnvVar = (id: string, field: "key" | "value", value: string) => {
-    setEnvVars(prev => prev.map(envVar => 
-      envVar.id === id ? { ...envVar, [field]: value } : envVar
-    ));
+    setEnvVars((prev) =>
+      prev.map((envVar) =>
+        envVar.id === id ? { ...envVar, [field]: value } : envVar
+      )
+    );
   };
 
   /**
    * Removes an environment variable
    */
   const removeEnvVar = (id: string) => {
-    setEnvVars(prev => prev.filter(envVar => envVar.id !== id));
+    setEnvVars((prev) => prev.filter((envVar) => envVar.id !== id));
+  };
+
+  /**
+   * Adds a new environment variable group
+   */
+  const addEnvGroup = () => {
+    const groupId = `group-${Date.now()}`;
+    const groupName =
+      newGroupName.trim() || `Group ${Object.keys(envGroups).length + 1}`;
+    const newGroup: EnvGroup = {
+      name: groupName,
+      variables: {},
+    };
+    setEnvGroups((prev) => ({ ...prev, [groupId]: newGroup }));
+    setNewGroupName("");
+    // Switch to the new group for editing
+    switchToGroup(groupId);
+  };
+
+  /**
+   * Removes an environment variable group
+   */
+  const removeEnvGroup = (groupId: string) => {
+    if (groupId === "default") {
+      // Cannot delete the default group
+      return;
+    }
+    setEnvGroups((prev) => {
+      const updated = { ...prev };
+      delete updated[groupId];
+      return updated;
+    });
+    // If we just deleted the current edit group, switch to default
+    if (currentEditGroupId === groupId) {
+      switchToGroup("default");
+    }
+    // If we deleted the active group, switch active to default
+    if (activeEnvGroupId === groupId) {
+      setActiveEnvGroupId("default");
+    }
+  };
+
+  /**
+   * Switches to editing a different environment variable group
+   */
+  const switchToGroup = (groupId: string) => {
+    // Save current envVars to current group before switching
+    if (currentEditGroupId && envGroups[currentEditGroupId]) {
+      const currentVariables = envVars.reduce((acc, { key, value }) => {
+        if (key && String(key).trim()) {
+          acc[key] = String(value);
+        }
+        return acc;
+      }, {} as Record<string, string>);
+
+      setEnvGroups((prev) => ({
+        ...prev,
+        [currentEditGroupId]: {
+          ...prev[currentEditGroupId],
+          variables: currentVariables,
+        },
+      }));
+    }
+
+    // Switch to the new group
+    setCurrentEditGroupId(groupId);
+
+    // Load the new group's variables
+    const group = envGroups[groupId];
+    if (group && group.variables) {
+      setEnvVars(
+        Object.entries(group.variables).map(([key, value], index) => ({
+          id: `env-${index}-${Date.now()}`,
+          key,
+          value: value as string,
+        }))
+      );
+    } else {
+      setEnvVars([]);
+    }
+  };
+
+  /**
+   * Sets a group as the active (effective) group
+   */
+  const setActiveGroup = (groupId: string) => {
+    setActiveEnvGroupId(groupId);
   };
 
   /**
@@ -368,702 +560,1047 @@ export const Settings: React.FC<SettingsProps> = ({
             </motion.div>
           </div>
         </div>
-      
-      {/* Error message */}
-      <AnimatePresence>
-        {error && (
-          <motion.div
-            initial={{ opacity: 0, y: 8 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: -8 }}
-            transition={{ duration: 0.15 }}
-            className="mx-4 mt-4 p-3 rounded-lg bg-destructive/10 border border-destructive/50 flex items-center gap-2 text-body-small text-destructive"
-          >
-            <AlertCircle className="h-4 w-4" />
-            {error}
-          </motion.div>
-        )}
-      </AnimatePresence>
-      
-      {/* Content */}
-      {loading ? (
-        <div className="flex-1 flex items-center justify-center">
-          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-        </div>
-      ) : (
-        <div className="flex-1 overflow-y-auto p-6">
-          <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-            <TabsList className="grid grid-cols-8 w-full mb-6 h-auto p-1">
-              <TabsTrigger value="general" className="py-2.5 px-3">General</TabsTrigger>
-              <TabsTrigger value="permissions" className="py-2.5 px-3">Permissions</TabsTrigger>
-              <TabsTrigger value="environment" className="py-2.5 px-3">Environment</TabsTrigger>
-              <TabsTrigger value="advanced" className="py-2.5 px-3">Advanced</TabsTrigger>
-              <TabsTrigger value="hooks" className="py-2.5 px-3">Hooks</TabsTrigger>
-              <TabsTrigger value="commands" className="py-2.5 px-3">Commands</TabsTrigger>
-              <TabsTrigger value="storage" className="py-2.5 px-3">Storage</TabsTrigger>
-              <TabsTrigger value="proxy" className="py-2.5 px-3">Proxy</TabsTrigger>
-            </TabsList>
-            
-            {/* General Settings */}
-            <TabsContent value="general" className="space-y-6 mt-6">
-              <Card className="p-6 space-y-6">
-                <div>
-                  <h3 className="text-heading-4 mb-4">General Settings</h3>
-                  
-                  <div className="space-y-4">
-                    {/* Theme Selector */}
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <Label>Theme</Label>
-                        <p className="text-caption text-muted-foreground mt-1">
-                          Choose your preferred color theme
-                        </p>
-                      </div>
-                      <div className="flex items-center gap-1 p-1 bg-muted/30 rounded-lg">
-                        <button
-                          onClick={() => setTheme('dark')}
-                          className={cn(
-                            "flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition-all",
-                            theme === 'dark' 
-                              ? "bg-background shadow-sm" 
-                              : "hover:bg-background/50"
-                          )}
-                        >
-                          {theme === 'dark' && <Check className="h-3 w-3" />}
-                          Dark
-                        </button>
-                        <button
-                          onClick={() => setTheme('gray')}
-                          className={cn(
-                            "flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition-all",
-                            theme === 'gray' 
-                              ? "bg-background shadow-sm" 
-                              : "hover:bg-background/50"
-                          )}
-                        >
-                          {theme === 'gray' && <Check className="h-3 w-3" />}
-                          Gray
-                        </button>
-                        <button
-                          onClick={() => setTheme('light')}
-                          className={cn(
-                            "flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition-all",
-                            theme === 'light' 
-                              ? "bg-background shadow-sm" 
-                              : "hover:bg-background/50"
-                          )}
-                        >
-                          {theme === 'light' && <Check className="h-3 w-3" />}
-                          Light
-                        </button>
-                        <button
-                          onClick={() => setTheme('custom')}
-                          className={cn(
-                            "flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition-all",
-                            theme === 'custom' 
-                              ? "bg-background shadow-sm" 
-                              : "hover:bg-background/50"
-                          )}
-                        >
-                          {theme === 'custom' && <Check className="h-3 w-3" />}
-                          Custom
-                        </button>
-                      </div>
-                    </div>
-                    
-                    {/* Custom Color Editor */}
-                    {theme === 'custom' && (
-                      <div className="space-y-4 p-4 border rounded-lg bg-muted/20">
-                        <h4 className="text-label">Custom Theme Colors</h4>
-                        
-                        <div className="grid grid-cols-2 gap-4">
-                          {/* Background Color */}
-                          <div className="space-y-2">
-                            <Label htmlFor="color-background" className="text-caption">Background</Label>
-                            <div className="flex gap-2">
-                              <Input
-                                id="color-background"
-                                type="text"
-                                value={customColors.background}
-                                onChange={(e) => setCustomColors({ background: e.target.value })}
-                                placeholder="oklch(0.12 0.01 240)"
-                                className="font-mono text-xs"
-                              />
-                              <div 
-                                className="w-10 h-10 rounded border"
-                                style={{ backgroundColor: customColors.background }}
-                              />
-                            </div>
-                          </div>
-                          
-                          {/* Foreground Color */}
-                          <div className="space-y-2">
-                            <Label htmlFor="color-foreground" className="text-caption">Foreground</Label>
-                            <div className="flex gap-2">
-                              <Input
-                                id="color-foreground"
-                                type="text"
-                                value={customColors.foreground}
-                                onChange={(e) => setCustomColors({ foreground: e.target.value })}
-                                placeholder="oklch(0.98 0.01 240)"
-                                className="font-mono text-xs"
-                              />
-                              <div 
-                                className="w-10 h-10 rounded border"
-                                style={{ backgroundColor: customColors.foreground }}
-                              />
-                            </div>
-                          </div>
-                          
-                          {/* Primary Color */}
-                          <div className="space-y-2">
-                            <Label htmlFor="color-primary" className="text-caption">Primary</Label>
-                            <div className="flex gap-2">
-                              <Input
-                                id="color-primary"
-                                type="text"
-                                value={customColors.primary}
-                                onChange={(e) => setCustomColors({ primary: e.target.value })}
-                                placeholder="oklch(0.98 0.01 240)"
-                                className="font-mono text-xs"
-                              />
-                              <div 
-                                className="w-10 h-10 rounded border"
-                                style={{ backgroundColor: customColors.primary }}
-                              />
-                            </div>
-                          </div>
-                          
-                          {/* Card Color */}
-                          <div className="space-y-2">
-                            <Label htmlFor="color-card" className="text-caption">Card</Label>
-                            <div className="flex gap-2">
-                              <Input
-                                id="color-card"
-                                type="text"
-                                value={customColors.card}
-                                onChange={(e) => setCustomColors({ card: e.target.value })}
-                                placeholder="oklch(0.14 0.01 240)"
-                                className="font-mono text-xs"
-                              />
-                              <div 
-                                className="w-10 h-10 rounded border"
-                                style={{ backgroundColor: customColors.card }}
-                              />
-                            </div>
-                          </div>
-                          
-                          {/* Accent Color */}
-                          <div className="space-y-2">
-                            <Label htmlFor="color-accent" className="text-caption">Accent</Label>
-                            <div className="flex gap-2">
-                              <Input
-                                id="color-accent"
-                                type="text"
-                                value={customColors.accent}
-                                onChange={(e) => setCustomColors({ accent: e.target.value })}
-                                placeholder="oklch(0.16 0.01 240)"
-                                className="font-mono text-xs"
-                              />
-                              <div 
-                                className="w-10 h-10 rounded border"
-                                style={{ backgroundColor: customColors.accent }}
-                              />
-                            </div>
-                          </div>
-                          
-                          {/* Destructive Color */}
-                          <div className="space-y-2">
-                            <Label htmlFor="color-destructive" className="text-caption">Destructive</Label>
-                            <div className="flex gap-2">
-                              <Input
-                                id="color-destructive"
-                                type="text"
-                                value={customColors.destructive}
-                                onChange={(e) => setCustomColors({ destructive: e.target.value })}
-                                placeholder="oklch(0.6 0.2 25)"
-                                className="font-mono text-xs"
-                              />
-                              <div 
-                                className="w-10 h-10 rounded border"
-                                style={{ backgroundColor: customColors.destructive }}
-                              />
-                            </div>
-                          </div>
-                        </div>
-                        
-                        <p className="text-caption text-muted-foreground">
-                          Use CSS color values (hex, rgb, oklch, etc.). Changes apply immediately.
-                        </p>
-                      </div>
-                    )}
-                    
-                    {/* Include Co-authored By */}
-                    <div className="flex items-center justify-between">
-                      <div className="space-y-0.5 flex-1">
-                        <Label htmlFor="coauthored">Include "Co-authored by Claude"</Label>
-                        <p className="text-caption text-muted-foreground">
-                          Add Claude attribution to git commits and pull requests
-                        </p>
-                      </div>
-                      <Switch
-                        id="coauthored"
-                        checked={settings?.includeCoAuthoredBy !== false}
-                        onCheckedChange={(checked) => updateSetting("includeCoAuthoredBy", checked)}
-                      />
-                    </div>
-                    
-                    {/* Verbose Output */}
-                    <div className="flex items-center justify-between">
-                      <div className="space-y-0.5 flex-1">
-                        <Label htmlFor="verbose">Verbose Output</Label>
-                        <p className="text-caption text-muted-foreground">
-                          Show full bash and command outputs
-                        </p>
-                      </div>
-                      <Switch
-                        id="verbose"
-                        checked={settings?.verbose === true}
-                        onCheckedChange={(checked) => updateSetting("verbose", checked)}
-                      />
-                    </div>
-                    
-                    {/* Cleanup Period */}
-                    <div className="space-y-2">
+
+        {/* Error message */}
+        <AnimatePresence>
+          {error && (
+            <motion.div
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -8 }}
+              transition={{ duration: 0.15 }}
+              className="mx-4 mt-4 p-3 rounded-lg bg-destructive/10 border border-destructive/50 flex items-center gap-2 text-body-small text-destructive"
+            >
+              <AlertCircle className="h-4 w-4" />
+              {error}
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        {/* Content */}
+        {loading ? (
+          <div className="flex-1 flex items-center justify-center">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          </div>
+        ) : (
+          <div className="flex-1 overflow-y-auto p-6">
+            <Tabs
+              value={activeTab}
+              onValueChange={setActiveTab}
+              className="w-full"
+            >
+              <TabsList className="grid grid-cols-8 w-full mb-6 h-auto p-1">
+                <TabsTrigger value="general" className="py-2.5 px-3">
+                  General
+                </TabsTrigger>
+                <TabsTrigger value="permissions" className="py-2.5 px-3">
+                  Permissions
+                </TabsTrigger>
+                <TabsTrigger value="environment" className="py-2.5 px-3">
+                  Environment
+                </TabsTrigger>
+                <TabsTrigger value="advanced" className="py-2.5 px-3">
+                  Advanced
+                </TabsTrigger>
+                <TabsTrigger value="hooks" className="py-2.5 px-3">
+                  Hooks
+                </TabsTrigger>
+                <TabsTrigger value="commands" className="py-2.5 px-3">
+                  Commands
+                </TabsTrigger>
+                <TabsTrigger value="storage" className="py-2.5 px-3">
+                  Storage
+                </TabsTrigger>
+                <TabsTrigger value="proxy" className="py-2.5 px-3">
+                  Proxy
+                </TabsTrigger>
+              </TabsList>
+
+              {/* General Settings */}
+              <TabsContent value="general" className="space-y-6 mt-6">
+                <Card className="p-6 space-y-6">
+                  <div>
+                    <h3 className="text-heading-4 mb-4">General Settings</h3>
+
+                    <div className="space-y-4">
+                      {/* Theme Selector */}
                       <div className="flex items-center justify-between">
-                        <div className="flex-1">
-                          <Label htmlFor="cleanup">Chat Transcript Retention (days)</Label>
+                        <div>
+                          <Label>Theme</Label>
                           <p className="text-caption text-muted-foreground mt-1">
-                            How long to retain chat transcripts locally (default: 30 days)
+                            Choose your preferred color theme
                           </p>
                         </div>
-                        <Input
-                          id="cleanup"
-                          type="number"
-                          min="1"
-                          placeholder="30"
-                          value={settings?.cleanupPeriodDays || ""}
-                          onChange={(e) => {
-                            const value = e.target.value ? parseInt(e.target.value) : undefined;
-                            updateSetting("cleanupPeriodDays", value);
+                        <div className="flex items-center gap-1 p-1 bg-muted/30 rounded-lg">
+                          <button
+                            onClick={() => setTheme("dark")}
+                            className={cn(
+                              "flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition-all",
+                              theme === "dark"
+                                ? "bg-background shadow-sm"
+                                : "hover:bg-background/50"
+                            )}
+                          >
+                            {theme === "dark" && <Check className="h-3 w-3" />}
+                            Dark
+                          </button>
+                          <button
+                            onClick={() => setTheme("gray")}
+                            className={cn(
+                              "flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition-all",
+                              theme === "gray"
+                                ? "bg-background shadow-sm"
+                                : "hover:bg-background/50"
+                            )}
+                          >
+                            {theme === "gray" && <Check className="h-3 w-3" />}
+                            Gray
+                          </button>
+                          <button
+                            onClick={() => setTheme("light")}
+                            className={cn(
+                              "flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition-all",
+                              theme === "light"
+                                ? "bg-background shadow-sm"
+                                : "hover:bg-background/50"
+                            )}
+                          >
+                            {theme === "light" && <Check className="h-3 w-3" />}
+                            Light
+                          </button>
+                          <button
+                            onClick={() => setTheme("custom")}
+                            className={cn(
+                              "flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition-all",
+                              theme === "custom"
+                                ? "bg-background shadow-sm"
+                                : "hover:bg-background/50"
+                            )}
+                          >
+                            {theme === "custom" && (
+                              <Check className="h-3 w-3" />
+                            )}
+                            Custom
+                          </button>
+                        </div>
+                      </div>
+
+                      {/* Custom Color Editor */}
+                      {theme === "custom" && (
+                        <div className="space-y-4 p-4 border rounded-lg bg-muted/20">
+                          <h4 className="text-label">Custom Theme Colors</h4>
+
+                          <div className="grid grid-cols-2 gap-4">
+                            {/* Background Color */}
+                            <div className="space-y-2">
+                              <Label
+                                htmlFor="color-background"
+                                className="text-caption"
+                              >
+                                Background
+                              </Label>
+                              <div className="flex gap-2">
+                                <Input
+                                  id="color-background"
+                                  type="text"
+                                  value={customColors.background}
+                                  onChange={(e) =>
+                                    setCustomColors({
+                                      background: e.target.value,
+                                    })
+                                  }
+                                  placeholder="oklch(0.12 0.01 240)"
+                                  className="font-mono text-xs"
+                                />
+                                <div
+                                  className="w-10 h-10 rounded border"
+                                  style={{
+                                    backgroundColor: customColors.background,
+                                  }}
+                                />
+                              </div>
+                            </div>
+
+                            {/* Foreground Color */}
+                            <div className="space-y-2">
+                              <Label
+                                htmlFor="color-foreground"
+                                className="text-caption"
+                              >
+                                Foreground
+                              </Label>
+                              <div className="flex gap-2">
+                                <Input
+                                  id="color-foreground"
+                                  type="text"
+                                  value={customColors.foreground}
+                                  onChange={(e) =>
+                                    setCustomColors({
+                                      foreground: e.target.value,
+                                    })
+                                  }
+                                  placeholder="oklch(0.98 0.01 240)"
+                                  className="font-mono text-xs"
+                                />
+                                <div
+                                  className="w-10 h-10 rounded border"
+                                  style={{
+                                    backgroundColor: customColors.foreground,
+                                  }}
+                                />
+                              </div>
+                            </div>
+
+                            {/* Primary Color */}
+                            <div className="space-y-2">
+                              <Label
+                                htmlFor="color-primary"
+                                className="text-caption"
+                              >
+                                Primary
+                              </Label>
+                              <div className="flex gap-2">
+                                <Input
+                                  id="color-primary"
+                                  type="text"
+                                  value={customColors.primary}
+                                  onChange={(e) =>
+                                    setCustomColors({ primary: e.target.value })
+                                  }
+                                  placeholder="oklch(0.98 0.01 240)"
+                                  className="font-mono text-xs"
+                                />
+                                <div
+                                  className="w-10 h-10 rounded border"
+                                  style={{
+                                    backgroundColor: customColors.primary,
+                                  }}
+                                />
+                              </div>
+                            </div>
+
+                            {/* Card Color */}
+                            <div className="space-y-2">
+                              <Label
+                                htmlFor="color-card"
+                                className="text-caption"
+                              >
+                                Card
+                              </Label>
+                              <div className="flex gap-2">
+                                <Input
+                                  id="color-card"
+                                  type="text"
+                                  value={customColors.card}
+                                  onChange={(e) =>
+                                    setCustomColors({ card: e.target.value })
+                                  }
+                                  placeholder="oklch(0.14 0.01 240)"
+                                  className="font-mono text-xs"
+                                />
+                                <div
+                                  className="w-10 h-10 rounded border"
+                                  style={{ backgroundColor: customColors.card }}
+                                />
+                              </div>
+                            </div>
+
+                            {/* Accent Color */}
+                            <div className="space-y-2">
+                              <Label
+                                htmlFor="color-accent"
+                                className="text-caption"
+                              >
+                                Accent
+                              </Label>
+                              <div className="flex gap-2">
+                                <Input
+                                  id="color-accent"
+                                  type="text"
+                                  value={customColors.accent}
+                                  onChange={(e) =>
+                                    setCustomColors({ accent: e.target.value })
+                                  }
+                                  placeholder="oklch(0.16 0.01 240)"
+                                  className="font-mono text-xs"
+                                />
+                                <div
+                                  className="w-10 h-10 rounded border"
+                                  style={{
+                                    backgroundColor: customColors.accent,
+                                  }}
+                                />
+                              </div>
+                            </div>
+
+                            {/* Destructive Color */}
+                            <div className="space-y-2">
+                              <Label
+                                htmlFor="color-destructive"
+                                className="text-caption"
+                              >
+                                Destructive
+                              </Label>
+                              <div className="flex gap-2">
+                                <Input
+                                  id="color-destructive"
+                                  type="text"
+                                  value={customColors.destructive}
+                                  onChange={(e) =>
+                                    setCustomColors({
+                                      destructive: e.target.value,
+                                    })
+                                  }
+                                  placeholder="oklch(0.6 0.2 25)"
+                                  className="font-mono text-xs"
+                                />
+                                <div
+                                  className="w-10 h-10 rounded border"
+                                  style={{
+                                    backgroundColor: customColors.destructive,
+                                  }}
+                                />
+                              </div>
+                            </div>
+                          </div>
+
+                          <p className="text-caption text-muted-foreground">
+                            Use CSS color values (hex, rgb, oklch, etc.).
+                            Changes apply immediately.
+                          </p>
+                        </div>
+                      )}
+
+                      {/* Include Co-authored By */}
+                      <div className="flex items-center justify-between">
+                        <div className="space-y-0.5 flex-1">
+                          <Label htmlFor="coauthored">
+                            Include "Co-authored by Claude"
+                          </Label>
+                          <p className="text-caption text-muted-foreground">
+                            Add Claude attribution to git commits and pull
+                            requests
+                          </p>
+                        </div>
+                        <Switch
+                          id="coauthored"
+                          checked={settings?.includeCoAuthoredBy !== false}
+                          onCheckedChange={(checked) =>
+                            updateSetting("includeCoAuthoredBy", checked)
+                          }
+                        />
+                      </div>
+
+                      {/* Verbose Output */}
+                      <div className="flex items-center justify-between">
+                        <div className="space-y-0.5 flex-1">
+                          <Label htmlFor="verbose">Verbose Output</Label>
+                          <p className="text-caption text-muted-foreground">
+                            Show full bash and command outputs
+                          </p>
+                        </div>
+                        <Switch
+                          id="verbose"
+                          checked={settings?.verbose === true}
+                          onCheckedChange={(checked) =>
+                            updateSetting("verbose", checked)
+                          }
+                        />
+                      </div>
+
+                      {/* Cleanup Period */}
+                      <div className="space-y-2">
+                        <div className="flex items-center justify-between">
+                          <div className="flex-1">
+                            <Label htmlFor="cleanup">
+                              Chat Transcript Retention (days)
+                            </Label>
+                            <p className="text-caption text-muted-foreground mt-1">
+                              How long to retain chat transcripts locally
+                              (default: 30 days)
+                            </p>
+                          </div>
+                          <Input
+                            id="cleanup"
+                            type="number"
+                            min="1"
+                            placeholder="30"
+                            value={settings?.cleanupPeriodDays || ""}
+                            onChange={(e) => {
+                              const value = e.target.value
+                                ? parseInt(e.target.value)
+                                : undefined;
+                              updateSetting("cleanupPeriodDays", value);
+                            }}
+                            className="w-24"
+                          />
+                        </div>
+                      </div>
+
+                      {/* Claude Binary Path Selector */}
+                      <div className="space-y-3">
+                        <ClaudeVersionSelector
+                          selectedPath={currentBinaryPath}
+                          onSelect={handleClaudeInstallationSelect}
+                          simplified={true}
+                        />
+                        {binaryPathChanged && (
+                          <p className="text-caption text-amber-600 dark:text-amber-400 flex items-center gap-1">
+                            <AlertCircle className="h-3 w-3" />
+                            Changes will be applied when you save settings.
+                          </p>
+                        )}
+                      </div>
+
+                      {/* Separator */}
+                      <div className="border-t border-border pt-4 mt-6" />
+
+                      {/* Analytics Toggle */}
+                      <div className="flex items-center justify-between">
+                        <div className="space-y-1">
+                          <Label htmlFor="analytics-enabled">
+                            Enable Analytics
+                          </Label>
+                          <p className="text-caption text-muted-foreground">
+                            Help improve opcode by sharing anonymous usage data
+                          </p>
+                        </div>
+                        <Switch
+                          id="analytics-enabled"
+                          checked={analyticsEnabled}
+                          onCheckedChange={async (checked) => {
+                            if (checked) {
+                              await analytics.enable();
+                              setAnalyticsEnabled(true);
+                              trackEvent.settingsChanged(
+                                "analytics_enabled",
+                                true
+                              );
+                              setToast({
+                                message: "Analytics enabled",
+                                type: "success",
+                              });
+                            } else {
+                              await analytics.disable();
+                              setAnalyticsEnabled(false);
+                              trackEvent.settingsChanged(
+                                "analytics_enabled",
+                                false
+                              );
+                              setToast({
+                                message: "Analytics disabled",
+                                type: "success",
+                              });
+                            }
                           }}
-                          className="w-24"
+                        />
+                      </div>
+
+                      {/* Privacy Info */}
+                      {analyticsEnabled && (
+                        <div className="rounded-lg border border-border bg-muted/50 p-3">
+                          <div className="flex gap-2">
+                            <Shield className="h-4 w-4 text-primary flex-shrink-0 mt-0.5" />
+                            <div className="space-y-1">
+                              <p className="text-xs font-medium text-foreground">
+                                Your privacy is protected
+                              </p>
+                              <ul className="text-xs text-muted-foreground space-y-0.5">
+                                <li>
+                                  • No personal information or file contents
+                                  collected
+                                </li>
+                                <li>• All data is anonymous with random IDs</li>
+                                <li>• You can disable analytics at any time</li>
+                              </ul>
+                            </div>
+                          </div>
+                        </div>
+                      )}
+
+                      {/* Tab Persistence Toggle */}
+                      <div className="flex items-center justify-between">
+                        <div className="space-y-1">
+                          <Label htmlFor="tab-persistence">
+                            Remember Open Tabs
+                          </Label>
+                          <p className="text-caption text-muted-foreground">
+                            Restore your tabs when you restart the app
+                          </p>
+                        </div>
+                        <Switch
+                          id="tab-persistence"
+                          checked={tabPersistenceEnabled}
+                          onCheckedChange={(checked) => {
+                            TabPersistenceService.setEnabled(checked);
+                            setTabPersistenceEnabled(checked);
+                            trackEvent.settingsChanged(
+                              "tab_persistence_enabled",
+                              checked
+                            );
+                            setToast({
+                              message: checked
+                                ? "Tab persistence enabled - your tabs will be restored on restart"
+                                : "Tab persistence disabled - tabs will not be saved",
+                              type: "success",
+                            });
+                          }}
+                        />
+                      </div>
+
+                      {/* Startup Intro Toggle */}
+                      <div className="flex items-center justify-between">
+                        <div className="space-y-1">
+                          <Label htmlFor="startup-intro">
+                            Show Welcome Intro on Startup
+                          </Label>
+                          <p className="text-caption text-muted-foreground">
+                            Display a brief welcome animation when the app
+                            launches
+                          </p>
+                        </div>
+                        <Switch
+                          id="startup-intro"
+                          checked={startupIntroEnabled}
+                          onCheckedChange={async (checked) => {
+                            setStartupIntroEnabled(checked);
+                            try {
+                              await api.saveSetting(
+                                "startup_intro_enabled",
+                                checked ? "true" : "false"
+                              );
+                              trackEvent.settingsChanged(
+                                "startup_intro_enabled",
+                                checked
+                              );
+                              setToast({
+                                message: checked
+                                  ? "Welcome intro enabled"
+                                  : "Welcome intro disabled",
+                                type: "success",
+                              });
+                            } catch (e) {
+                              setToast({
+                                message: "Failed to update preference",
+                                type: "error",
+                              });
+                            }
+                          }}
                         />
                       </div>
                     </div>
-                    
-                    {/* Claude Binary Path Selector */}
-                    <div className="space-y-3">
-                      <ClaudeVersionSelector
-                        selectedPath={currentBinaryPath}
-                        onSelect={handleClaudeInstallationSelect}
-                        simplified={true}
-                      />
-                      {binaryPathChanged && (
-                        <p className="text-caption text-amber-600 dark:text-amber-400 flex items-center gap-1">
-                          <AlertCircle className="h-3 w-3" />
-                          Changes will be applied when you save settings.
-                        </p>
-                      )}
-                    </div>
+                  </div>
+                </Card>
+              </TabsContent>
 
-                    {/* Separator */}
-                    <div className="border-t border-border pt-4 mt-6" />
-                    
-                    {/* Analytics Toggle */}
-                    <div className="flex items-center justify-between">
-                      <div className="space-y-1">
-                        <Label htmlFor="analytics-enabled">Enable Analytics</Label>
-                        <p className="text-caption text-muted-foreground">
-                          Help improve opcode by sharing anonymous usage data
-                        </p>
-                      </div>
-                      <Switch
-                        id="analytics-enabled"
-                        checked={analyticsEnabled}
-                        onCheckedChange={async (checked) => {
-                          if (checked) {
-                            await analytics.enable();
-                            setAnalyticsEnabled(true);
-                            trackEvent.settingsChanged('analytics_enabled', true);
-                            setToast({ message: "Analytics enabled", type: "success" });
-                          } else {
-                            await analytics.disable();
-                            setAnalyticsEnabled(false);
-                            trackEvent.settingsChanged('analytics_enabled', false);
-                            setToast({ message: "Analytics disabled", type: "success" });
-                          }
-                        }}
-                      />
-                    </div>
-                    
-                    {/* Privacy Info */}
-                    {analyticsEnabled && (
-                      <div className="rounded-lg border border-border bg-muted/50 p-3">
-                        <div className="flex gap-2">
-                          <Shield className="h-4 w-4 text-primary flex-shrink-0 mt-0.5" />
-                          <div className="space-y-1">
-                            <p className="text-xs font-medium text-foreground">Your privacy is protected</p>
-                            <ul className="text-xs text-muted-foreground space-y-0.5">
-                              <li>• No personal information or file contents collected</li>
-                              <li>• All data is anonymous with random IDs</li>
-                              <li>• You can disable analytics at any time</li>
-                            </ul>
-                          </div>
-                        </div>
-                      </div>
-                    )}
-                    
-                    {/* Tab Persistence Toggle */}
-                    <div className="flex items-center justify-between">
-                      <div className="space-y-1">
-                        <Label htmlFor="tab-persistence">Remember Open Tabs</Label>
-                        <p className="text-caption text-muted-foreground">
-                          Restore your tabs when you restart the app
-                        </p>
-                      </div>
-                      <Switch
-                        id="tab-persistence"
-                        checked={tabPersistenceEnabled}
-                        onCheckedChange={(checked) => {
-                          TabPersistenceService.setEnabled(checked);
-                          setTabPersistenceEnabled(checked);
-                          trackEvent.settingsChanged('tab_persistence_enabled', checked);
-                          setToast({ 
-                            message: checked 
-                              ? "Tab persistence enabled - your tabs will be restored on restart" 
-                              : "Tab persistence disabled - tabs will not be saved", 
-                            type: "success" 
-                          });
-                        }}
-                      />
-                    </div>
-
-                    {/* Startup Intro Toggle */}
-                    <div className="flex items-center justify-between">
-                      <div className="space-y-1">
-                        <Label htmlFor="startup-intro">Show Welcome Intro on Startup</Label>
-                        <p className="text-caption text-muted-foreground">
-                          Display a brief welcome animation when the app launches
-                        </p>
-                      </div>
-                      <Switch
-                        id="startup-intro"
-                        checked={startupIntroEnabled}
-                        onCheckedChange={async (checked) => {
-                          setStartupIntroEnabled(checked);
-                          try {
-                            await api.saveSetting('startup_intro_enabled', checked ? 'true' : 'false');
-                            trackEvent.settingsChanged('startup_intro_enabled', checked);
-                            setToast({ 
-                              message: checked 
-                                ? 'Welcome intro enabled' 
-                                : 'Welcome intro disabled', 
-                              type: 'success' 
-                            });
-                          } catch (e) {
-                            setToast({ message: 'Failed to update preference', type: 'error' });
-                          }
-                        }}
-                      />
-                    </div>
-                  </div>
-                </div>
-              </Card>
-            </TabsContent>
-            
-            {/* Permissions Settings */}
-            <TabsContent value="permissions" className="space-y-6">
-              <Card className="p-6">
-                <div className="space-y-6">
-                  <div>
-                    <h3 className="text-heading-4 mb-2">Permission Rules</h3>
-                    <p className="text-body-small text-muted-foreground mb-4">
-                      Control which tools Claude Code can use without manual approval
-                    </p>
-                  </div>
-                  
-                  {/* Allow Rules */}
-                  <div className="space-y-3">
-                    <div className="flex items-center justify-between">
-                      <Label className="text-label text-green-500">Allow Rules</Label>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => addPermissionRule("allow")}
-                        className="gap-2 hover:border-green-500/50 hover:text-green-500"
-                      >
-                        <Plus className="h-3 w-3" />
-                        Add Rule
-                      </Button>
-                    </div>
-                    <div className="space-y-2">
-                      {allowRules.length === 0 ? (
-                        <p className="text-xs text-muted-foreground py-2">
-                          No allow rules configured. Claude will ask for approval for all tools.
-                        </p>
-                      ) : (
-                        allowRules.map((rule) => (
-                          <motion.div
-                            key={rule.id}
-                            initial={{ opacity: 0, x: -8 }}
-                            animate={{ opacity: 1, x: 0 }}
-                            transition={{ duration: 0.15 }}
-                            className="flex items-center gap-2"
-                          >
-                            <Input
-                              placeholder="e.g., Bash(npm run test:*)"
-                              value={rule.value}
-                              onChange={(e) => updatePermissionRule("allow", rule.id, e.target.value)}
-                              className="flex-1"
-                            />
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              onClick={() => removePermissionRule("allow", rule.id)}
-                              className="h-8 w-8"
-                            >
-                              <Trash2 className="h-4 w-4" />
-                            </Button>
-                          </motion.div>
-                        ))
-                      )}
-                    </div>
-                  </div>
-                  
-                  {/* Deny Rules */}
-                  <div className="space-y-3">
-                    <div className="flex items-center justify-between">
-                      <Label className="text-label text-red-500">Deny Rules</Label>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => addPermissionRule("deny")}
-                        className="gap-2 hover:border-red-500/50 hover:text-red-500"
-                      >
-                        <Plus className="h-3 w-3" />
-                        Add Rule
-                      </Button>
-                    </div>
-                    <div className="space-y-2">
-                      {denyRules.length === 0 ? (
-                        <p className="text-xs text-muted-foreground py-2">
-                          No deny rules configured.
-                        </p>
-                      ) : (
-                        denyRules.map((rule) => (
-                          <motion.div
-                            key={rule.id}
-                            initial={{ opacity: 0, x: -8 }}
-                            animate={{ opacity: 1, x: 0 }}
-                            transition={{ duration: 0.15 }}
-                            className="flex items-center gap-2"
-                          >
-                            <Input
-                              placeholder="e.g., Bash(curl:*)"
-                              value={rule.value}
-                              onChange={(e) => updatePermissionRule("deny", rule.id, e.target.value)}
-                              className="flex-1"
-                            />
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              onClick={() => removePermissionRule("deny", rule.id)}
-                              className="h-8 w-8"
-                            >
-                              <Trash2 className="h-4 w-4" />
-                            </Button>
-                          </motion.div>
-                        ))
-                      )}
-                    </div>
-                  </div>
-                  
-                  <div className="pt-2 space-y-2">
-                    <p className="text-xs text-muted-foreground">
-                      <strong>Examples:</strong>
-                    </p>
-                    <ul className="text-caption text-muted-foreground space-y-1 ml-4">
-                      <li>• <code className="px-1 py-0.5 rounded bg-green-500/10 text-green-600 dark:text-green-400">Bash</code> - Allow all bash commands</li>
-                      <li>• <code className="px-1 py-0.5 rounded bg-green-500/10 text-green-600 dark:text-green-400">Bash(npm run build)</code> - Allow exact command</li>
-                      <li>• <code className="px-1 py-0.5 rounded bg-green-500/10 text-green-600 dark:text-green-400">Bash(npm run test:*)</code> - Allow commands with prefix</li>
-                      <li>• <code className="px-1 py-0.5 rounded bg-green-500/10 text-green-600 dark:text-green-400">Read(~/.zshrc)</code> - Allow reading specific file</li>
-                      <li>• <code className="px-1 py-0.5 rounded bg-green-500/10 text-green-600 dark:text-green-400">Edit(docs/**)</code> - Allow editing files in docs directory</li>
-                    </ul>
-                  </div>
-                </div>
-              </Card>
-            </TabsContent>
-            
-            {/* Environment Variables */}
-            <TabsContent value="environment" className="space-y-6">
-              <Card className="p-6">
-                <div className="space-y-6">
-                  <div className="flex items-center justify-between">
+              {/* Permissions Settings */}
+              <TabsContent value="permissions" className="space-y-6">
+                <Card className="p-6">
+                  <div className="space-y-6">
                     <div>
-                      <h3 className="text-heading-4">Environment Variables</h3>
-                      <p className="text-sm text-muted-foreground mt-1">
-                        Environment variables applied to every Claude Code session
+                      <h3 className="text-heading-4 mb-2">Permission Rules</h3>
+                      <p className="text-body-small text-muted-foreground mb-4">
+                        Control which tools Claude Code can use without manual
+                        approval
                       </p>
                     </div>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={addEnvVar}
-                      className="gap-2"
-                    >
-                      <Plus className="h-3 w-3" />
-                      Add Variable
-                    </Button>
-                  </div>
-                  
-                  <div className="space-y-3">
-                    {envVars.length === 0 ? (
-                      <p className="text-xs text-muted-foreground py-2">
-                        No environment variables configured.
-                      </p>
-                    ) : (
-                      envVars.map((envVar) => (
-                        <motion.div
-                          key={envVar.id}
-                          initial={{ opacity: 0, x: -20 }}
-                          animate={{ opacity: 1, x: 0 }}
-                          className="flex items-center gap-2"
+
+                    {/* Allow Rules */}
+                    <div className="space-y-3">
+                      <div className="flex items-center justify-between">
+                        <Label className="text-label text-green-500">
+                          Allow Rules
+                        </Label>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => addPermissionRule("allow")}
+                          className="gap-2 hover:border-green-500/50 hover:text-green-500"
                         >
+                          <Plus className="h-3 w-3" />
+                          Add Rule
+                        </Button>
+                      </div>
+                      <div className="space-y-2">
+                        {allowRules.length === 0 ? (
+                          <p className="text-xs text-muted-foreground py-2">
+                            No allow rules configured. Claude will ask for
+                            approval for all tools.
+                          </p>
+                        ) : (
+                          allowRules.map((rule) => (
+                            <motion.div
+                              key={rule.id}
+                              initial={{ opacity: 0, x: -8 }}
+                              animate={{ opacity: 1, x: 0 }}
+                              transition={{ duration: 0.15 }}
+                              className="flex items-center gap-2"
+                            >
+                              <Input
+                                placeholder="e.g., Bash(npm run test:*)"
+                                value={rule.value}
+                                onChange={(e) =>
+                                  updatePermissionRule(
+                                    "allow",
+                                    rule.id,
+                                    e.target.value
+                                  )
+                                }
+                                className="flex-1"
+                              />
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                onClick={() =>
+                                  removePermissionRule("allow", rule.id)
+                                }
+                                className="h-8 w-8"
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            </motion.div>
+                          ))
+                        )}
+                      </div>
+                    </div>
+
+                    {/* Deny Rules */}
+                    <div className="space-y-3">
+                      <div className="flex items-center justify-between">
+                        <Label className="text-label text-red-500">
+                          Deny Rules
+                        </Label>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => addPermissionRule("deny")}
+                          className="gap-2 hover:border-red-500/50 hover:text-red-500"
+                        >
+                          <Plus className="h-3 w-3" />
+                          Add Rule
+                        </Button>
+                      </div>
+                      <div className="space-y-2">
+                        {denyRules.length === 0 ? (
+                          <p className="text-xs text-muted-foreground py-2">
+                            No deny rules configured.
+                          </p>
+                        ) : (
+                          denyRules.map((rule) => (
+                            <motion.div
+                              key={rule.id}
+                              initial={{ opacity: 0, x: -8 }}
+                              animate={{ opacity: 1, x: 0 }}
+                              transition={{ duration: 0.15 }}
+                              className="flex items-center gap-2"
+                            >
+                              <Input
+                                placeholder="e.g., Bash(curl:*)"
+                                value={rule.value}
+                                onChange={(e) =>
+                                  updatePermissionRule(
+                                    "deny",
+                                    rule.id,
+                                    e.target.value
+                                  )
+                                }
+                                className="flex-1"
+                              />
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                onClick={() =>
+                                  removePermissionRule("deny", rule.id)
+                                }
+                                className="h-8 w-8"
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            </motion.div>
+                          ))
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="pt-2 space-y-2">
+                      <p className="text-xs text-muted-foreground">
+                        <strong>Examples:</strong>
+                      </p>
+                      <ul className="text-caption text-muted-foreground space-y-1 ml-4">
+                        <li>
+                          •{" "}
+                          <code className="px-1 py-0.5 rounded bg-green-500/10 text-green-600 dark:text-green-400">
+                            Bash
+                          </code>{" "}
+                          - Allow all bash commands
+                        </li>
+                        <li>
+                          •{" "}
+                          <code className="px-1 py-0.5 rounded bg-green-500/10 text-green-600 dark:text-green-400">
+                            Bash(npm run build)
+                          </code>{" "}
+                          - Allow exact command
+                        </li>
+                        <li>
+                          •{" "}
+                          <code className="px-1 py-0.5 rounded bg-green-500/10 text-green-600 dark:text-green-400">
+                            Bash(npm run test:*)
+                          </code>{" "}
+                          - Allow commands with prefix
+                        </li>
+                        <li>
+                          •{" "}
+                          <code className="px-1 py-0.5 rounded bg-green-500/10 text-green-600 dark:text-green-400">
+                            Read(~/.zshrc)
+                          </code>{" "}
+                          - Allow reading specific file
+                        </li>
+                        <li>
+                          •{" "}
+                          <code className="px-1 py-0.5 rounded bg-green-500/10 text-green-600 dark:text-green-400">
+                            Edit(docs/**)
+                          </code>{" "}
+                          - Allow editing files in docs directory
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </Card>
+              </TabsContent>
+
+              {/* Environment Variables */}
+              <TabsContent value="environment" className="space-y-6">
+                <Card className="p-6">
+                  <div className="space-y-6">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <h3 className="text-heading-4">
+                          Environment Variables
+                        </h3>
+                        <p className="text-sm text-muted-foreground mt-1">
+                          Manage environment variable groups for different
+                          configurations
+                        </p>
+                      </div>
+                    </div>
+
+                    {/* Environment Group Selector */}
+                    <div className="space-y-3">
+                      <Label className="text-sm font-medium flex items-center gap-2">
+                        <Layers className="h-4 w-4" />
+                        Environment Groups
+                      </Label>
+                      <div className="flex flex-wrap gap-2">
+                        {Object.entries(envGroups).map(([groupId, group]) => (
+                          <div key={groupId} className="flex items-center">
+                            <Button
+                              variant={
+                                currentEditGroupId === groupId
+                                  ? "default"
+                                  : "outline"
+                              }
+                              size="sm"
+                              onClick={() => switchToGroup(groupId)}
+                              className="gap-2"
+                            >
+                              {editingGroupName === groupId ? (
+                                <Input
+                                  value={group.name}
+                                  onChange={(e) => {
+                                    setEnvGroups((prev) => ({
+                                      ...prev,
+                                      [groupId]: {
+                                        ...prev[groupId],
+                                        name: e.target.value,
+                                      },
+                                    }));
+                                  }}
+                                  onBlur={() => setEditingGroupName(null)}
+                                  onKeyDown={(e) => {
+                                    if (e.key === "Enter")
+                                      setEditingGroupName(null);
+                                  }}
+                                  className="h-5 w-24 text-xs"
+                                  autoFocus
+                                />
+                              ) : (
+                                <>
+                                  {group.name}
+                                  {activeEnvGroupId === groupId && (
+                                    <Check className="h-3 w-3 text-green-500" />
+                                  )}
+                                </>
+                              )}
+                            </Button>
+                            {groupId !== "default" &&
+                              currentEditGroupId === groupId && (
+                                <div className="flex ml-1">
+                                  <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    className="h-7 w-7"
+                                    onClick={() => setEditingGroupName(groupId)}
+                                  >
+                                    <Pencil className="h-3 w-3" />
+                                  </Button>
+                                  <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    className="h-7 w-7 hover:text-destructive"
+                                    onClick={() => removeEnvGroup(groupId)}
+                                  >
+                                    <Trash2 className="h-3 w-3" />
+                                  </Button>
+                                </div>
+                              )}
+                          </div>
+                        ))}
+                        <div className="flex items-center gap-1">
                           <Input
-                            placeholder="KEY"
-                            value={envVar.key}
-                            onChange={(e) => updateEnvVar(envVar.id, "key", e.target.value)}
-                            className="flex-1 font-mono text-sm"
-                          />
-                          <span className="text-muted-foreground">=</span>
-                          <Input
-                            placeholder="value"
-                            value={envVar.value}
-                            onChange={(e) => updateEnvVar(envVar.id, "value", e.target.value)}
-                            className="flex-1 font-mono text-sm"
+                            placeholder="New group name"
+                            value={newGroupName}
+                            onChange={(e) => setNewGroupName(e.target.value)}
+                            className="h-8 w-32 text-xs"
+                            onKeyDown={(e) => {
+                              if (e.key === "Enter") addEnvGroup();
+                            }}
                           />
                           <Button
-                            variant="ghost"
-                            size="icon"
-                            onClick={() => removeEnvVar(envVar.id)}
-                            className="h-8 w-8 hover:text-destructive"
+                            variant="outline"
+                            size="sm"
+                            onClick={addEnvGroup}
+                            className="h-8"
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <Plus className="h-3 w-3" />
                           </Button>
-                        </motion.div>
-                      ))
-                    )}
-                  </div>
-                  
-                  <div className="pt-2 space-y-2">
-                    <p className="text-xs text-muted-foreground">
-                      <strong>Common variables:</strong>
-                    </p>
-                    <ul className="text-caption text-muted-foreground space-y-1 ml-4">
-                      <li>• <code className="px-1 py-0.5 rounded bg-blue-500/10 text-blue-600 dark:text-blue-400">CLAUDE_CODE_ENABLE_TELEMETRY</code> - Enable/disable telemetry (0 or 1)</li>
-                      <li>• <code className="px-1 py-0.5 rounded bg-blue-500/10 text-blue-600 dark:text-blue-400">ANTHROPIC_MODEL</code> - Custom model name</li>
-                      <li>• <code className="px-1 py-0.5 rounded bg-blue-500/10 text-blue-600 dark:text-blue-400">DISABLE_COST_WARNINGS</code> - Disable cost warnings (1)</li>
-                    </ul>
-                  </div>
-                </div>
-              </Card>
-            </TabsContent>
-            {/* Advanced Settings */}
-            <TabsContent value="advanced" className="space-y-6">
-              <Card className="p-6">
-                <div className="space-y-6">
-                  <div>
-                    <h3 className="text-base font-semibold mb-4">Advanced Settings</h3>
-                    <p className="text-sm text-muted-foreground mb-6">
-                      Additional configuration options for advanced users
-                    </p>
-                  </div>
-                  
-                  {/* API Key Helper */}
-                  <div className="space-y-2">
-                    <Label htmlFor="apiKeyHelper">API Key Helper Script</Label>
-                    <Input
-                      id="apiKeyHelper"
-                      placeholder="/path/to/generate_api_key.sh"
-                      value={settings?.apiKeyHelper || ""}
-                      onChange={(e) => updateSetting("apiKeyHelper", e.target.value || undefined)}
-                    />
-                    <p className="text-xs text-muted-foreground">
-                      Custom script to generate auth values for API requests
-                    </p>
-                  </div>
-                  
-                  {/* Raw JSON Editor */}
-                  <div className="space-y-2">
-                    <Label>Raw Settings (JSON)</Label>
-                    <div className="p-3 rounded-md bg-muted font-mono text-xs overflow-x-auto whitespace-pre-wrap">
-                      <pre>{JSON.stringify(settings, null, 2)}</pre>
+                        </div>
+                      </div>
+                      {currentEditGroupId !== activeEnvGroupId && (
+                        <Button
+                          variant="secondary"
+                          size="sm"
+                          onClick={() => setActiveGroup(currentEditGroupId)}
+                          className="gap-2"
+                        >
+                          <Check className="h-3 w-3" />
+                          Set as Active
+                        </Button>
+                      )}
+                      <p className="text-xs text-muted-foreground">
+                        Active group:{" "}
+                        <strong>
+                          {envGroups[activeEnvGroupId]?.name || "Default"}
+                        </strong>{" "}
+                        (used in sessions)
+                      </p>
                     </div>
-                    <p className="text-xs text-muted-foreground">
-                      This shows the raw JSON that will be saved to ~/.claude/settings.json
-                    </p>
+
+                    {/* Variables for Current Group */}
+                    <div className="border-t pt-4">
+                      <div className="flex items-center justify-between mb-3">
+                        <Label className="text-sm font-medium">
+                          Variables in "
+                          {envGroups[currentEditGroupId]?.name || "Default"}"
+                        </Label>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={addEnvVar}
+                          className="gap-2"
+                        >
+                          <Plus className="h-3 w-3" />
+                          Add Variable
+                        </Button>
+                      </div>
+
+                      <div className="space-y-3">
+                        {envVars.length === 0 ? (
+                          <p className="text-xs text-muted-foreground py-2">
+                            No environment variables configured in this group.
+                          </p>
+                        ) : (
+                          envVars.map((envVar) => (
+                            <motion.div
+                              key={envVar.id}
+                              initial={{ opacity: 0, x: -20 }}
+                              animate={{ opacity: 1, x: 0 }}
+                              className="flex items-center gap-2"
+                            >
+                              <Input
+                                placeholder="KEY"
+                                value={envVar.key}
+                                onChange={(e) =>
+                                  updateEnvVar(envVar.id, "key", e.target.value)
+                                }
+                                className="flex-1 font-mono text-sm"
+                              />
+                              <span className="text-muted-foreground">=</span>
+                              <Input
+                                placeholder="value"
+                                value={envVar.value}
+                                onChange={(e) =>
+                                  updateEnvVar(
+                                    envVar.id,
+                                    "value",
+                                    e.target.value
+                                  )
+                                }
+                                className="flex-1 font-mono text-sm"
+                              />
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => removeEnvVar(envVar.id)}
+                                className="h-8 w-8 hover:text-destructive"
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            </motion.div>
+                          ))
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="pt-2 space-y-2">
+                      <p className="text-xs text-muted-foreground">
+                        <strong>Common variables:</strong>
+                      </p>
+                      <ul className="text-caption text-muted-foreground space-y-1 ml-4">
+                        <li>
+                          •{" "}
+                          <code className="px-1 py-0.5 rounded bg-blue-500/10 text-blue-600 dark:text-blue-400">
+                            CLAUDE_CODE_ENABLE_TELEMETRY
+                          </code>{" "}
+                          - Enable/disable telemetry (0 or 1)
+                        </li>
+                        <li>
+                          •{" "}
+                          <code className="px-1 py-0.5 rounded bg-blue-500/10 text-blue-600 dark:text-blue-400">
+                            ANTHROPIC_MODEL
+                          </code>{" "}
+                          - Custom model name
+                        </li>
+                        <li>
+                          •{" "}
+                          <code className="px-1 py-0.5 rounded bg-blue-500/10 text-blue-600 dark:text-blue-400">
+                            DISABLE_COST_WARNINGS
+                          </code>{" "}
+                          - Disable cost warnings (1)
+                        </li>
+                      </ul>
+                    </div>
                   </div>
-                </div>
-              </Card>
-            </TabsContent>
-            
-            {/* Hooks Settings */}
-            <TabsContent value="hooks" className="space-y-6">
-              <Card className="p-6">
-                <div className="space-y-4">
-                  <div>
-                    <h3 className="text-base font-semibold mb-2">User Hooks</h3>
-                    <p className="text-body-small text-muted-foreground mb-4">
-                      Configure hooks that apply to all Claude Code sessions for your user account.
-                      These are stored in <code className="mx-1 px-2 py-1 bg-muted rounded text-xs">~/.claude/settings.json</code>
-                    </p>
+                </Card>
+              </TabsContent>
+              {/* Advanced Settings */}
+              <TabsContent value="advanced" className="space-y-6">
+                <Card className="p-6">
+                  <div className="space-y-6">
+                    <div>
+                      <h3 className="text-base font-semibold mb-4">
+                        Advanced Settings
+                      </h3>
+                      <p className="text-sm text-muted-foreground mb-6">
+                        Additional configuration options for advanced users
+                      </p>
+                    </div>
+
+                    {/* API Key Helper */}
+                    <div className="space-y-2">
+                      <Label htmlFor="apiKeyHelper">
+                        API Key Helper Script
+                      </Label>
+                      <Input
+                        id="apiKeyHelper"
+                        placeholder="/path/to/generate_api_key.sh"
+                        value={settings?.apiKeyHelper || ""}
+                        onChange={(e) =>
+                          updateSetting(
+                            "apiKeyHelper",
+                            e.target.value || undefined
+                          )
+                        }
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Custom script to generate auth values for API requests
+                      </p>
+                    </div>
+
+                    {/* Raw JSON Editor */}
+                    <div className="space-y-2">
+                      <Label>Raw Settings (JSON)</Label>
+                      <div className="p-3 rounded-md bg-muted font-mono text-xs overflow-x-auto whitespace-pre-wrap">
+                        <pre>{JSON.stringify(settings, null, 2)}</pre>
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        This shows the raw JSON that will be saved to
+                        ~/.claude/settings.json
+                      </p>
+                    </div>
                   </div>
-                  
-                  <HooksEditor
-                    key={activeTab}
-                    scope="user"
-                    className="border-0"
-                    hideActions={true}
-                    onChange={(hasChanges, getHooks) => {
-                      setUserHooksChanged(hasChanges);
-                      getUserHooks.current = getHooks;
+                </Card>
+              </TabsContent>
+
+              {/* Hooks Settings */}
+              <TabsContent value="hooks" className="space-y-6">
+                <Card className="p-6">
+                  <div className="space-y-4">
+                    <div>
+                      <h3 className="text-base font-semibold mb-2">
+                        User Hooks
+                      </h3>
+                      <p className="text-body-small text-muted-foreground mb-4">
+                        Configure hooks that apply to all Claude Code sessions
+                        for your user account. These are stored in{" "}
+                        <code className="mx-1 px-2 py-1 bg-muted rounded text-xs">
+                          ~/.claude/settings.json
+                        </code>
+                      </p>
+                    </div>
+
+                    <HooksEditor
+                      key={activeTab}
+                      scope="user"
+                      className="border-0"
+                      hideActions={true}
+                      onChange={(hasChanges, getHooks) => {
+                        setUserHooksChanged(hasChanges);
+                        getUserHooks.current = getHooks;
+                      }}
+                    />
+                  </div>
+                </Card>
+              </TabsContent>
+
+              {/* Commands Tab */}
+              <TabsContent value="commands">
+                <Card className="p-6">
+                  <SlashCommandsManager className="p-0" />
+                </Card>
+              </TabsContent>
+
+              {/* Storage Tab */}
+              <TabsContent value="storage">
+                <StorageTab />
+              </TabsContent>
+
+              {/* Proxy Settings */}
+              <TabsContent value="proxy">
+                <Card className="p-6">
+                  <ProxySettings
+                    setToast={setToast}
+                    onChange={(hasChanges, _getSettings, save) => {
+                      setProxySettingsChanged(hasChanges);
+                      saveProxySettings.current = save;
                     }}
                   />
-                </div>
-              </Card>
-            </TabsContent>
-            
-            {/* Commands Tab */}
-            <TabsContent value="commands">
-              <Card className="p-6">
-                <SlashCommandsManager className="p-0" />
-              </Card>
-            </TabsContent>
-            
-            {/* Storage Tab */}
-            <TabsContent value="storage">
-              <StorageTab />
-            </TabsContent>
-            
-            {/* Proxy Settings */}
-            <TabsContent value="proxy">
-              <Card className="p-6">
-                <ProxySettings 
-                  setToast={setToast}
-                  onChange={(hasChanges, _getSettings, save) => {
-                    setProxySettingsChanged(hasChanges);
-                    saveProxySettings.current = save;
-                  }}
-                />
-              </Card>
-            </TabsContent>
-            
-          </Tabs>
-        </div>
-      )}
+                </Card>
+              </TabsContent>
+            </Tabs>
+          </div>
+        )}
       </div>
-      
+
       {/* Toast Notification */}
       <ToastContainer>
         {toast && (
@@ -1074,8 +1611,6 @@ export const Settings: React.FC<SettingsProps> = ({
           />
         )}
       </ToastContainer>
-      
-      
     </div>
   );
-}; 
+};

--- a/src/components/claude-code-session/useClaudeMessages.ts
+++ b/src/components/claude-code-session/useClaudeMessages.ts
@@ -1,17 +1,9 @@
-import { useState, useCallback, useRef, useEffect } from 'react';
-import { api } from '@/lib/api';
-import { getEnvironmentInfo } from '@/lib/apiAdapter';
-import type { ClaudeStreamMessage } from '../AgentExecution';
+import { useState, useCallback, useRef, useEffect } from "react";
+import { api } from "@/lib/api";
+import { getEnvironmentInfo } from "@/lib/apiAdapter";
+import type { ClaudeStreamMessage } from "../AgentExecution";
 
-// Conditional import for Tauri
-let tauriListen: any;
-try {
-  if (typeof window !== 'undefined' && window.__TAURI__) {
-    tauriListen = require('@tauri-apps/api/event').listen;
-  }
-} catch (e) {
-  console.log('[useClaudeMessages] Tauri event API not available, using web mode');
-}
+import { listen } from "@tauri-apps/api/event";
 
 interface UseClaudeMessagesOptions {
   onSessionInfo?: (info: { sessionId: string; projectId: string }) => void;
@@ -24,67 +16,98 @@ export function useClaudeMessages(options: UseClaudeMessagesOptions = {}) {
   const [rawJsonlOutput, setRawJsonlOutput] = useState<string[]>([]);
   const [isStreaming, setIsStreaming] = useState(false);
   const [currentSessionId, setCurrentSessionId] = useState<string | null>(null);
-  
+
   const eventListenerRef = useRef<(() => void) | null>(null);
   const accumulatedContentRef = useRef<{ [key: string]: string }>({});
 
-  const handleMessage = useCallback((message: ClaudeStreamMessage) => {
-    console.log('[TRACE] useClaudeMessages.handleMessage called with:', message);
-    
-    if ((message as any).type === "start") {
-      console.log('[TRACE] Start message detected - clearing accumulated content and setting streaming=true');
-      // Clear accumulated content for new stream
-      accumulatedContentRef.current = {};
-      setIsStreaming(true);
-      options.onStreamingChange?.(true, currentSessionId);
-    } else if ((message as any).type === "partial") {
-      console.log('[TRACE] Partial message detected');
-      if (message.tool_calls && message.tool_calls.length > 0) {
-        message.tool_calls.forEach((toolCall: any) => {
-          if (toolCall.content && toolCall.partial_tool_call_index !== undefined) {
-            const key = `tool-${toolCall.partial_tool_call_index}`;
-            if (!accumulatedContentRef.current[key]) {
-              accumulatedContentRef.current[key] = "";
+  const handleMessage = useCallback(
+    (message: ClaudeStreamMessage) => {
+      console.log(
+        "[TRACE] useClaudeMessages.handleMessage called with:",
+        message
+      );
+
+      if ((message as any).type === "start") {
+        console.log(
+          "[TRACE] Start message detected - clearing accumulated content and setting streaming=true"
+        );
+        // Clear accumulated content for new stream
+        accumulatedContentRef.current = {};
+        setIsStreaming(true);
+        options.onStreamingChange?.(true, currentSessionId);
+      } else if ((message as any).type === "partial") {
+        console.log("[TRACE] Partial message detected");
+        if (message.tool_calls && message.tool_calls.length > 0) {
+          message.tool_calls.forEach((toolCall: any) => {
+            if (
+              toolCall.content &&
+              toolCall.partial_tool_call_index !== undefined
+            ) {
+              const key = `tool-${toolCall.partial_tool_call_index}`;
+              if (!accumulatedContentRef.current[key]) {
+                accumulatedContentRef.current[key] = "";
+              }
+              accumulatedContentRef.current[key] += toolCall.content;
+              toolCall.accumulated_content = accumulatedContentRef.current[key];
             }
-            accumulatedContentRef.current[key] += toolCall.content;
-            toolCall.accumulated_content = accumulatedContentRef.current[key];
-          }
-        });
+          });
+        }
+      } else if (
+        (message as any).type === "response" &&
+        message.message?.usage
+      ) {
+        console.log("[TRACE] Response message with usage detected");
+        const totalTokens =
+          (message.message.usage.input_tokens || 0) +
+          (message.message.usage.output_tokens || 0);
+        console.log("[TRACE] Total tokens:", totalTokens);
+        options.onTokenUpdate?.(totalTokens);
+      } else if (
+        (message as any).type === "error" ||
+        (message as any).type === "response"
+      ) {
+        console.log(
+          "[TRACE] Error or response message detected - setting streaming=false"
+        );
+        setIsStreaming(false);
+        options.onStreamingChange?.(false, currentSessionId);
+      } else if ((message as any).type === "output") {
+        console.log(
+          "[TRACE] Output message detected, content:",
+          (message as any).content
+        );
+      } else {
+        console.log("[TRACE] Unknown message type:", (message as any).type);
       }
-    } else if ((message as any).type === "response" && message.message?.usage) {
-      console.log('[TRACE] Response message with usage detected');
-      const totalTokens = (message.message.usage.input_tokens || 0) + 
-                         (message.message.usage.output_tokens || 0);
-      console.log('[TRACE] Total tokens:', totalTokens);
-      options.onTokenUpdate?.(totalTokens);
-    } else if ((message as any).type === "error" || (message as any).type === "response") {
-      console.log('[TRACE] Error or response message detected - setting streaming=false');
-      setIsStreaming(false);
-      options.onStreamingChange?.(false, currentSessionId);
-    } else if ((message as any).type === "output") {
-      console.log('[TRACE] Output message detected, content:', (message as any).content);
-    } else {
-      console.log('[TRACE] Unknown message type:', (message as any).type);
-    }
 
-    console.log('[TRACE] Adding message to state');
-    setMessages(prev => {
-      const newMessages = [...prev, message];
-      console.log('[TRACE] Total messages now:', newMessages.length);
-      return newMessages;
-    });
-    setRawJsonlOutput(prev => [...prev, JSON.stringify(message)]);
-
-    // Extract session info
-    if ((message as any).type === "session_info" && (message as any).session_id && (message as any).project_id) {
-      console.log('[TRACE] Session info detected:', (message as any).session_id, (message as any).project_id);
-      options.onSessionInfo?.({
-        sessionId: (message as any).session_id,
-        projectId: (message as any).project_id
+      console.log("[TRACE] Adding message to state");
+      setMessages((prev) => {
+        const newMessages = [...prev, message];
+        console.log("[TRACE] Total messages now:", newMessages.length);
+        return newMessages;
       });
-      setCurrentSessionId((message as any).session_id);
-    }
-  }, [currentSessionId, options]);
+      setRawJsonlOutput((prev) => [...prev, JSON.stringify(message)]);
+
+      // Extract session info
+      if (
+        (message as any).type === "session_info" &&
+        (message as any).session_id &&
+        (message as any).project_id
+      ) {
+        console.log(
+          "[TRACE] Session info detected:",
+          (message as any).session_id,
+          (message as any).project_id
+        );
+        options.onSessionInfo?.({
+          sessionId: (message as any).session_id,
+          projectId: (message as any).project_id,
+        });
+        setCurrentSessionId((message as any).session_id);
+      }
+    },
+    [currentSessionId, options]
+  );
 
   const clearMessages = useCallback(() => {
     setMessages([]);
@@ -126,59 +149,72 @@ export function useClaudeMessages(options: UseClaudeMessagesOptions = {}) {
   // Set up event listener
   useEffect(() => {
     const setupListener = async () => {
-      console.log('[TRACE] useClaudeMessages setupListener called');
+      console.log("[TRACE] useClaudeMessages setupListener called");
       if (eventListenerRef.current) {
-        console.log('[TRACE] Cleaning up existing event listener');
+        console.log("[TRACE] Cleaning up existing event listener");
         eventListenerRef.current();
       }
-      
+
       const envInfo = getEnvironmentInfo();
-      console.log('[TRACE] Environment info:', envInfo);
-      
-      if (envInfo.isTauri && tauriListen) {
+      console.log("[TRACE] Environment info:", envInfo);
+
+      if (envInfo.isTauri) {
         // Tauri mode - use Tauri's event system
-        console.log('[TRACE] Setting up Tauri event listener for claude-stream');
-        eventListenerRef.current = await tauriListen("claude-stream", (event: any) => {
-          console.log('[TRACE] Tauri event received:', event);
-          try {
-            const message = JSON.parse(event.payload) as ClaudeStreamMessage;
-            console.log('[TRACE] Parsed Tauri message:', message);
-            handleMessage(message);
-          } catch (error) {
-            console.error("[TRACE] Failed to parse Claude stream message:", error);
+        console.log(
+          "[TRACE] Setting up Tauri event listener for claude-stream"
+        );
+        eventListenerRef.current = await listen(
+          "claude-stream",
+          (event: any) => {
+            console.log("[TRACE] Tauri event received:", event);
+            try {
+              const message = JSON.parse(event.payload) as ClaudeStreamMessage;
+              console.log("[TRACE] Parsed Tauri message:", message);
+              handleMessage(message);
+            } catch (error) {
+              console.error(
+                "[TRACE] Failed to parse Claude stream message:",
+                error
+              );
+            }
           }
-        });
-        console.log('[TRACE] Tauri event listener setup complete');
+        );
+        console.log("[TRACE] Tauri event listener setup complete");
       } else {
         // Web mode - use DOM events (these are dispatched by our WebSocket handler)
-        console.log('[TRACE] Setting up web event listener for claude-output');
+        console.log("[TRACE] Setting up web event listener for claude-output");
         const webEventHandler = (event: any) => {
-          console.log('[TRACE] Web event received:', event);
-          console.log('[TRACE] Event detail:', event.detail);
+          console.log("[TRACE] Web event received:", event);
+          console.log("[TRACE] Event detail:", event.detail);
           try {
             const message = event.detail as ClaudeStreamMessage;
-            console.log('[TRACE] Calling handleMessage with:', message);
+            console.log("[TRACE] Calling handleMessage with:", message);
             handleMessage(message);
           } catch (error) {
-            console.error("[TRACE] Failed to parse Claude stream message:", error);
+            console.error(
+              "[TRACE] Failed to parse Claude stream message:",
+              error
+            );
           }
         };
-        
-        window.addEventListener('claude-output', webEventHandler);
-        console.log('[TRACE] Web event listener added for claude-output');
-        console.log('[TRACE] Event listener function:', webEventHandler);
-        
+
+        window.addEventListener("claude-output", webEventHandler);
+        console.log("[TRACE] Web event listener added for claude-output");
+        console.log("[TRACE] Event listener function:", webEventHandler);
+
         // Test if event listener is working
         setTimeout(() => {
-          console.log('[TRACE] Testing event dispatch...');
-          window.dispatchEvent(new CustomEvent('claude-output', {
-            detail: { type: 'test', message: 'test event' }
-          }));
+          console.log("[TRACE] Testing event dispatch...");
+          window.dispatchEvent(
+            new CustomEvent("claude-output", {
+              detail: { type: "test", message: "test event" },
+            })
+          );
         }, 1000);
-        
+
         eventListenerRef.current = () => {
-          console.log('[TRACE] Removing web event listener');
-          window.removeEventListener('claude-output', webEventHandler);
+          console.log("[TRACE] Removing web event listener");
+          window.removeEventListener("claude-output", webEventHandler);
         };
       }
     };

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,8 +1,8 @@
-import { apiCall } from './apiAdapter';
-import type { HooksConfiguration } from '@/types/hooks';
+import { apiCall } from "./apiAdapter";
+import type { HooksConfiguration } from "@/types/hooks";
 
 /** Process type for tracking in ProcessRegistry */
-export type ProcessType = 
+export type ProcessType =
   | { AgentRun: { agent_id: number; agent_name: string } }
   | { ClaudeSession: { session_id: string } };
 
@@ -54,10 +54,21 @@ export interface Session {
 }
 
 /**
+ * Represents an environment variable group
+ */
+export interface EnvGroup {
+  name: string;
+  variables: Record<string, string>;
+}
+
+/**
  * Represents the settings from ~/.claude/settings.json
  */
 export interface ClaudeSettings {
   [key: string]: any;
+  env?: Record<string, string>;
+  envGroups?: Record<string, EnvGroup>;
+  activeEnvGroup?: string;
 }
 
 /**
@@ -302,7 +313,11 @@ export interface SessionTimeline {
 /**
  * Strategy for automatic checkpoint creation
  */
-export type CheckpointStrategy = 'manual' | 'per_prompt' | 'per_tool_use' | 'smart';
+export type CheckpointStrategy =
+  | "manual"
+  | "per_prompt"
+  | "per_tool_use"
+  | "smart";
 
 /**
  * Result of a checkpoint operation
@@ -481,7 +496,7 @@ export const api = {
    */
   async createProject(path: string): Promise<Project> {
     try {
-      return await apiCall<Project>('create_project', { path });
+      return await apiCall<Project>("create_project", { path });
     } catch (error) {
       console.error("Failed to create project:", error);
       throw error;
@@ -495,7 +510,7 @@ export const api = {
    */
   async getProjectSessions(projectId: string): Promise<Session[]> {
     try {
-      return await apiCall<Session[]>('get_project_sessions', { projectId });
+      return await apiCall<Session[]>("get_project_sessions", { projectId });
     } catch (error) {
       console.error("Failed to get project sessions:", error);
       throw error;
@@ -508,7 +523,7 @@ export const api = {
    */
   async fetchGitHubAgents(): Promise<GitHubAgentFile[]> {
     try {
-      return await apiCall<GitHubAgentFile[]>('fetch_github_agents');
+      return await apiCall<GitHubAgentFile[]>("fetch_github_agents");
     } catch (error) {
       console.error("Failed to fetch GitHub agents:", error);
       throw error;
@@ -522,7 +537,9 @@ export const api = {
    */
   async fetchGitHubAgentContent(downloadUrl: string): Promise<AgentExport> {
     try {
-      return await apiCall<AgentExport>('fetch_github_agent_content', { downloadUrl });
+      return await apiCall<AgentExport>("fetch_github_agent_content", {
+        downloadUrl,
+      });
     } catch (error) {
       console.error("Failed to fetch GitHub agent content:", error);
       throw error;
@@ -536,7 +553,7 @@ export const api = {
    */
   async importAgentFromGitHub(downloadUrl: string): Promise<Agent> {
     try {
-      return await apiCall<Agent>('import_agent_from_github', { downloadUrl });
+      return await apiCall<Agent>("import_agent_from_github", { downloadUrl });
     } catch (error) {
       console.error("Failed to import agent from GitHub:", error);
       throw error;
@@ -549,15 +566,17 @@ export const api = {
    */
   async getClaudeSettings(): Promise<ClaudeSettings> {
     try {
-      const result = await apiCall<{ data: ClaudeSettings }>("get_claude_settings");
+      const result = await apiCall<{ data: ClaudeSettings }>(
+        "get_claude_settings"
+      );
       console.log("Raw result from get_claude_settings:", result);
-      
+
       // The Rust backend returns ClaudeSettings { data: ... }
       // We need to extract the data field
-      if (result && typeof result === 'object' && 'data' in result) {
+      if (result && typeof result === "object" && "data" in result) {
         return result.data;
       }
-      
+
       // If the result is already the settings object, return it
       return result as ClaudeSettings;
     } catch (error) {
@@ -641,7 +660,9 @@ export const api = {
    */
   async findClaudeMdFiles(projectPath: string): Promise<ClaudeMdFile[]> {
     try {
-      return await apiCall<ClaudeMdFile[]>("find_claude_md_files", { projectPath });
+      return await apiCall<ClaudeMdFile[]>("find_claude_md_files", {
+        projectPath,
+      });
     } catch (error) {
       console.error("Failed to find CLAUDE.md files:", error);
       throw error;
@@ -670,7 +691,10 @@ export const api = {
    */
   async saveClaudeMdFile(filePath: string, content: string): Promise<string> {
     try {
-      return await apiCall<string>("save_claude_md_file", { filePath, content });
+      return await apiCall<string>("save_claude_md_file", {
+        filePath,
+        content,
+      });
     } catch (error) {
       console.error("Failed to save CLAUDE.md file:", error);
       throw error;
@@ -678,14 +702,14 @@ export const api = {
   },
 
   // Agent API methods
-  
+
   /**
    * Lists all CC agents
    * @returns Promise resolving to an array of agents
    */
   async listAgents(): Promise<Agent[]> {
     try {
-      return await apiCall<Agent[]>('list_agents');
+      return await apiCall<Agent[]>("list_agents");
     } catch (error) {
       console.error("Failed to list agents:", error);
       throw error;
@@ -703,21 +727,21 @@ export const api = {
    * @returns Promise resolving to the created agent
    */
   async createAgent(
-    name: string, 
-    icon: string, 
-    system_prompt: string, 
-    default_task?: string, 
+    name: string,
+    icon: string,
+    system_prompt: string,
+    default_task?: string,
     model?: string,
     hooks?: string
   ): Promise<Agent> {
     try {
-      return await apiCall<Agent>('create_agent', { 
-        name, 
-        icon, 
+      return await apiCall<Agent>("create_agent", {
+        name,
+        icon,
         systemPrompt: system_prompt,
         defaultTask: default_task,
         model,
-        hooks
+        hooks,
       });
     } catch (error) {
       console.error("Failed to create agent:", error);
@@ -737,23 +761,23 @@ export const api = {
    * @returns Promise resolving to the updated agent
    */
   async updateAgent(
-    id: number, 
-    name: string, 
-    icon: string, 
-    system_prompt: string, 
-    default_task?: string, 
+    id: number,
+    name: string,
+    icon: string,
+    system_prompt: string,
+    default_task?: string,
     model?: string,
     hooks?: string
   ): Promise<Agent> {
     try {
-      return await apiCall<Agent>('update_agent', { 
-        id, 
-        name, 
-        icon, 
+      return await apiCall<Agent>("update_agent", {
+        id,
+        name,
+        icon,
         systemPrompt: system_prompt,
         defaultTask: default_task,
         model,
-        hooks
+        hooks,
       });
     } catch (error) {
       console.error("Failed to update agent:", error);
@@ -768,7 +792,7 @@ export const api = {
    */
   async deleteAgent(id: number): Promise<void> {
     try {
-      return await apiCall('delete_agent', { id });
+      return await apiCall("delete_agent", { id });
     } catch (error) {
       console.error("Failed to delete agent:", error);
       throw error;
@@ -782,7 +806,7 @@ export const api = {
    */
   async getAgent(id: number): Promise<Agent> {
     try {
-      return await apiCall<Agent>('get_agent', { id });
+      return await apiCall<Agent>("get_agent", { id });
     } catch (error) {
       console.error("Failed to get agent:", error);
       throw error;
@@ -796,7 +820,7 @@ export const api = {
    */
   async exportAgent(id: number): Promise<string> {
     try {
-      return await apiCall<string>('export_agent', { id });
+      return await apiCall<string>("export_agent", { id });
     } catch (error) {
       console.error("Failed to export agent:", error);
       throw error;
@@ -810,7 +834,7 @@ export const api = {
    */
   async importAgent(jsonData: string): Promise<Agent> {
     try {
-      return await apiCall<Agent>('import_agent', { jsonData });
+      return await apiCall<Agent>("import_agent", { jsonData });
     } catch (error) {
       console.error("Failed to import agent:", error);
       throw error;
@@ -824,7 +848,7 @@ export const api = {
    */
   async importAgentFromFile(filePath: string): Promise<Agent> {
     try {
-      return await apiCall<Agent>('import_agent_from_file', { filePath });
+      return await apiCall<Agent>("import_agent_from_file", { filePath });
     } catch (error) {
       console.error("Failed to import agent from file:", error);
       throw error;
@@ -839,13 +863,27 @@ export const api = {
    * @param model - Optional model override
    * @returns Promise resolving to the run ID when execution starts
    */
-  async executeAgent(agentId: number, projectPath: string, task: string, model?: string): Promise<number> {
+  async executeAgent(
+    agentId: number,
+    projectPath: string,
+    task: string,
+    model?: string
+  ): Promise<number> {
     try {
-      return await apiCall<number>('execute_agent', { agentId, projectPath, task, model });
+      return await apiCall<number>("execute_agent", {
+        agentId,
+        projectPath,
+        task,
+        model,
+      });
     } catch (error) {
       console.error("Failed to execute agent:", error);
       // Return a sentinel value to indicate error
-      throw new Error(`Failed to execute agent: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      throw new Error(
+        `Failed to execute agent: ${
+          error instanceof Error ? error.message : "Unknown error"
+        }`
+      );
     }
   },
 
@@ -856,7 +894,9 @@ export const api = {
    */
   async listAgentRuns(agentId?: number): Promise<AgentRunWithMetrics[]> {
     try {
-      return await apiCall<AgentRunWithMetrics[]>('list_agent_runs', { agentId });
+      return await apiCall<AgentRunWithMetrics[]>("list_agent_runs", {
+        agentId,
+      });
     } catch (error) {
       console.error("Failed to list agent runs:", error);
       // Return empty array instead of throwing to prevent UI crashes
@@ -869,9 +909,14 @@ export const api = {
    * @param agentId - Optional agent ID to filter runs
    * @returns Promise resolving to an array of agent runs with metrics
    */
-  async listAgentRunsWithMetrics(agentId?: number): Promise<AgentRunWithMetrics[]> {
+  async listAgentRunsWithMetrics(
+    agentId?: number
+  ): Promise<AgentRunWithMetrics[]> {
     try {
-      return await apiCall<AgentRunWithMetrics[]>('list_agent_runs_with_metrics', { agentId });
+      return await apiCall<AgentRunWithMetrics[]>(
+        "list_agent_runs_with_metrics",
+        { agentId }
+      );
     } catch (error) {
       console.error("Failed to list agent runs with metrics:", error);
       // Return empty array instead of throwing to prevent UI crashes
@@ -886,10 +931,14 @@ export const api = {
    */
   async getAgentRun(id: number): Promise<AgentRunWithMetrics> {
     try {
-      return await apiCall<AgentRunWithMetrics>('get_agent_run', { id });
+      return await apiCall<AgentRunWithMetrics>("get_agent_run", { id });
     } catch (error) {
       console.error("Failed to get agent run:", error);
-      throw new Error(`Failed to get agent run: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      throw new Error(
+        `Failed to get agent run: ${
+          error instanceof Error ? error.message : "Unknown error"
+        }`
+      );
     }
   },
 
@@ -898,12 +947,21 @@ export const api = {
    * @param id - The run ID
    * @returns Promise resolving to the agent run with metrics
    */
-  async getAgentRunWithRealTimeMetrics(id: number): Promise<AgentRunWithMetrics> {
+  async getAgentRunWithRealTimeMetrics(
+    id: number
+  ): Promise<AgentRunWithMetrics> {
     try {
-      return await apiCall<AgentRunWithMetrics>('get_agent_run_with_real_time_metrics', { id });
+      return await apiCall<AgentRunWithMetrics>(
+        "get_agent_run_with_real_time_metrics",
+        { id }
+      );
     } catch (error) {
       console.error("Failed to get agent run with real-time metrics:", error);
-      throw new Error(`Failed to get agent run with real-time metrics: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      throw new Error(
+        `Failed to get agent run with real-time metrics: ${
+          error instanceof Error ? error.message : "Unknown error"
+        }`
+      );
     }
   },
 
@@ -913,10 +971,14 @@ export const api = {
    */
   async listRunningAgentSessions(): Promise<AgentRun[]> {
     try {
-      return await apiCall<AgentRun[]>('list_running_sessions');
+      return await apiCall<AgentRun[]>("list_running_sessions");
     } catch (error) {
       console.error("Failed to list running agent sessions:", error);
-      throw new Error(`Failed to list running agent sessions: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      throw new Error(
+        `Failed to list running agent sessions: ${
+          error instanceof Error ? error.message : "Unknown error"
+        }`
+      );
     }
   },
 
@@ -927,10 +989,14 @@ export const api = {
    */
   async killAgentSession(runId: number): Promise<boolean> {
     try {
-      return await apiCall<boolean>('kill_agent_session', { runId });
+      return await apiCall<boolean>("kill_agent_session", { runId });
     } catch (error) {
       console.error("Failed to kill agent session:", error);
-      throw new Error(`Failed to kill agent session: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      throw new Error(
+        `Failed to kill agent session: ${
+          error instanceof Error ? error.message : "Unknown error"
+        }`
+      );
     }
   },
 
@@ -941,10 +1007,14 @@ export const api = {
    */
   async getSessionStatus(runId: number): Promise<string | null> {
     try {
-      return await apiCall<string | null>('get_session_status', { runId });
+      return await apiCall<string | null>("get_session_status", { runId });
     } catch (error) {
       console.error("Failed to get session status:", error);
-      throw new Error(`Failed to get session status: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      throw new Error(
+        `Failed to get session status: ${
+          error instanceof Error ? error.message : "Unknown error"
+        }`
+      );
     }
   },
 
@@ -954,10 +1024,14 @@ export const api = {
    */
   async cleanupFinishedProcesses(): Promise<number[]> {
     try {
-      return await apiCall<number[]>('cleanup_finished_processes');
+      return await apiCall<number[]>("cleanup_finished_processes");
     } catch (error) {
       console.error("Failed to cleanup finished processes:", error);
-      throw new Error(`Failed to cleanup finished processes: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      throw new Error(
+        `Failed to cleanup finished processes: ${
+          error instanceof Error ? error.message : "Unknown error"
+        }`
+      );
     }
   },
 
@@ -968,10 +1042,14 @@ export const api = {
    */
   async getSessionOutput(runId: number): Promise<string> {
     try {
-      return await apiCall<string>('get_session_output', { runId });
+      return await apiCall<string>("get_session_output", { runId });
     } catch (error) {
       console.error("Failed to get session output:", error);
-      throw new Error(`Failed to get session output: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      throw new Error(
+        `Failed to get session output: ${
+          error instanceof Error ? error.message : "Unknown error"
+        }`
+      );
     }
   },
 
@@ -982,10 +1060,14 @@ export const api = {
    */
   async getLiveSessionOutput(runId: number): Promise<string> {
     try {
-      return await apiCall<string>('get_live_session_output', { runId });
+      return await apiCall<string>("get_live_session_output", { runId });
     } catch (error) {
       console.error("Failed to get live session output:", error);
-      throw new Error(`Failed to get live session output: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      throw new Error(
+        `Failed to get live session output: ${
+          error instanceof Error ? error.message : "Unknown error"
+        }`
+      );
     }
   },
 
@@ -996,17 +1078,24 @@ export const api = {
    */
   async streamSessionOutput(runId: number): Promise<void> {
     try {
-      return await apiCall<void>('stream_session_output', { runId });
+      return await apiCall<void>("stream_session_output", { runId });
     } catch (error) {
       console.error("Failed to start streaming session output:", error);
-      throw new Error(`Failed to start streaming session output: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      throw new Error(
+        `Failed to start streaming session output: ${
+          error instanceof Error ? error.message : "Unknown error"
+        }`
+      );
     }
   },
 
   /**
    * Loads the JSONL history for a specific session
    */
-  async loadSessionHistory(sessionId: string, projectId: string): Promise<any[]> {
+  async loadSessionHistory(
+    sessionId: string,
+    projectId: string
+  ): Promise<any[]> {
     return apiCall("load_session_history", { sessionId, projectId });
   },
 
@@ -1018,7 +1107,7 @@ export const api = {
    */
   async loadAgentSessionHistory(sessionId: string): Promise<any[]> {
     try {
-      return await apiCall<any[]>('load_agent_session_history', { sessionId });
+      return await apiCall<any[]>("load_agent_session_history", { sessionId });
     } catch (error) {
       console.error("Failed to load agent session history:", error);
       throw error;
@@ -1028,22 +1117,40 @@ export const api = {
   /**
    * Executes a new interactive Claude Code session with streaming output
    */
-  async executeClaudeCode(projectPath: string, prompt: string, model: string): Promise<void> {
+  async executeClaudeCode(
+    projectPath: string,
+    prompt: string,
+    model: string
+  ): Promise<void> {
     return apiCall("execute_claude_code", { projectPath, prompt, model });
   },
 
   /**
    * Continues an existing Claude Code conversation with streaming output
    */
-  async continueClaudeCode(projectPath: string, prompt: string, model: string): Promise<void> {
+  async continueClaudeCode(
+    projectPath: string,
+    prompt: string,
+    model: string
+  ): Promise<void> {
     return apiCall("continue_claude_code", { projectPath, prompt, model });
   },
 
   /**
    * Resumes an existing Claude Code session by ID with streaming output
    */
-  async resumeClaudeCode(projectPath: string, sessionId: string, prompt: string, model: string): Promise<void> {
-    return apiCall("resume_claude_code", { projectPath, sessionId, prompt, model });
+  async resumeClaudeCode(
+    projectPath: string,
+    sessionId: string,
+    prompt: string,
+    model: string
+  ): Promise<void> {
+    return apiCall("resume_claude_code", {
+      projectPath,
+      sessionId,
+      prompt,
+      model,
+    });
   },
 
   /**
@@ -1104,9 +1211,15 @@ export const api = {
    * @param endDate - End date (ISO format)
    * @returns Promise resolving to usage statistics
    */
-  async getUsageByDateRange(startDate: string, endDate: string): Promise<UsageStats> {
+  async getUsageByDateRange(
+    startDate: string,
+    endDate: string
+  ): Promise<UsageStats> {
     try {
-      return await apiCall<UsageStats>("get_usage_by_date_range", { startDate, endDate });
+      return await apiCall<UsageStats>("get_usage_by_date_range", {
+        startDate,
+        endDate,
+      });
     } catch (error) {
       console.error("Failed to get usage by date range:", error);
       throw error;
@@ -1166,7 +1279,7 @@ export const api = {
       projectId,
       projectPath,
       messageIndex,
-      description
+      description,
     });
   },
 
@@ -1183,7 +1296,7 @@ export const api = {
       checkpointId,
       sessionId,
       projectId,
-      projectPath
+      projectPath,
     });
   },
 
@@ -1198,7 +1311,7 @@ export const api = {
     return apiCall("list_checkpoints", {
       sessionId,
       projectId,
-      projectPath
+      projectPath,
     });
   },
 
@@ -1219,7 +1332,7 @@ export const api = {
       projectId,
       projectPath,
       newSessionId,
-      description
+      description,
     });
   },
 
@@ -1234,7 +1347,7 @@ export const api = {
     return apiCall("get_session_timeline", {
       sessionId,
       projectId,
-      projectPath
+      projectPath,
     });
   },
 
@@ -1253,7 +1366,7 @@ export const api = {
       projectId,
       projectPath,
       autoCheckpointEnabled,
-      checkpointStrategy
+      checkpointStrategy,
     });
   },
 
@@ -1271,7 +1384,7 @@ export const api = {
         fromCheckpointId,
         toCheckpointId,
         sessionId,
-        projectId
+        projectId,
       });
     } catch (error) {
       console.error("Failed to get checkpoint diff:", error);
@@ -1293,7 +1406,7 @@ export const api = {
         sessionId,
         projectId,
         projectPath,
-        message
+        message,
       });
     } catch (error) {
       console.error("Failed to track checkpoint message:", error);
@@ -1315,7 +1428,7 @@ export const api = {
         sessionId,
         projectId,
         projectPath,
-        message
+        message,
       });
     } catch (error) {
       console.error("Failed to check auto checkpoint:", error);
@@ -1337,7 +1450,7 @@ export const api = {
         sessionId,
         projectId,
         projectPath,
-        keepCount
+        keepCount,
       });
     } catch (error) {
       console.error("Failed to cleanup old checkpoints:", error);
@@ -1362,7 +1475,7 @@ export const api = {
       return await apiCall("get_checkpoint_settings", {
         sessionId,
         projectId,
-        projectPath
+        projectPath,
       });
     } catch (error) {
       console.error("Failed to get checkpoint settings:", error);
@@ -1386,12 +1499,17 @@ export const api = {
    * Tracks a batch of messages for a session for checkpointing
    */
   trackSessionMessages: (
-    sessionId: string, 
-    projectId: string, 
-    projectPath: string, 
+    sessionId: string,
+    projectId: string,
+    projectPath: string,
     messages: string[]
   ): Promise<void> =>
-    apiCall("track_session_messages", { sessionId, projectId, projectPath, messages }),
+    apiCall("track_session_messages", {
+      sessionId,
+      projectId,
+      projectPath,
+      messages,
+    }),
 
   /**
    * Adds a new MCP server
@@ -1413,7 +1531,7 @@ export const api = {
         args,
         env,
         url,
-        scope
+        scope,
       });
     } catch (error) {
       console.error("Failed to add MCP server:", error);
@@ -1463,9 +1581,17 @@ export const api = {
   /**
    * Adds an MCP server from JSON configuration
    */
-  async mcpAddJson(name: string, jsonConfig: string, scope: string = "local"): Promise<AddServerResult> {
+  async mcpAddJson(
+    name: string,
+    jsonConfig: string,
+    scope: string = "local"
+  ): Promise<AddServerResult> {
     try {
-      return await apiCall<AddServerResult>("mcp_add_json", { name, jsonConfig, scope });
+      return await apiCall<AddServerResult>("mcp_add_json", {
+        name,
+        jsonConfig,
+        scope,
+      });
     } catch (error) {
       console.error("Failed to add MCP server from JSON:", error);
       throw error;
@@ -1475,9 +1601,13 @@ export const api = {
   /**
    * Imports MCP servers from Claude Desktop
    */
-  async mcpAddFromClaudeDesktop(scope: string = "local"): Promise<ImportResult> {
+  async mcpAddFromClaudeDesktop(
+    scope: string = "local"
+  ): Promise<ImportResult> {
     try {
-      return await apiCall<ImportResult>("mcp_add_from_claude_desktop", { scope });
+      return await apiCall<ImportResult>("mcp_add_from_claude_desktop", {
+        scope,
+      });
     } catch (error) {
       console.error("Failed to import from Claude Desktop:", error);
       throw error;
@@ -1525,7 +1655,9 @@ export const api = {
    */
   async mcpGetServerStatus(): Promise<Record<string, ServerStatus>> {
     try {
-      return await apiCall<Record<string, ServerStatus>>("mcp_get_server_status");
+      return await apiCall<Record<string, ServerStatus>>(
+        "mcp_get_server_status"
+      );
     } catch (error) {
       console.error("Failed to get server status:", error);
       throw error;
@@ -1537,7 +1669,9 @@ export const api = {
    */
   async mcpReadProjectConfig(projectPath: string): Promise<MCPProjectConfig> {
     try {
-      return await apiCall<MCPProjectConfig>("mcp_read_project_config", { projectPath });
+      return await apiCall<MCPProjectConfig>("mcp_read_project_config", {
+        projectPath,
+      });
     } catch (error) {
       console.error("Failed to read project MCP config:", error);
       throw error;
@@ -1547,9 +1681,15 @@ export const api = {
   /**
    * Saves .mcp.json to the current project
    */
-  async mcpSaveProjectConfig(projectPath: string, config: MCPProjectConfig): Promise<string> {
+  async mcpSaveProjectConfig(
+    projectPath: string,
+    config: MCPProjectConfig
+  ): Promise<string> {
     try {
-      return await apiCall<string>("mcp_save_project_config", { projectPath, config });
+      return await apiCall<string>("mcp_save_project_config", {
+        projectPath,
+        config,
+      });
     } catch (error) {
       console.error("Failed to save project MCP config:", error);
       throw error;
@@ -1741,14 +1881,14 @@ export const api = {
   async getSetting(key: string): Promise<string | null> {
     try {
       // Fast path: check localStorage mirror to avoid startup flicker
-      if (typeof window !== 'undefined' && 'localStorage' in window) {
+      if (typeof window !== "undefined" && "localStorage" in window) {
         const cached = window.localStorage.getItem(`app_setting:${key}`);
         if (cached !== null) {
           return cached;
         }
       }
       // Use storageReadTable to safely query the app_settings table
-      const result = await this.storageReadTable('app_settings', 1, 1000);
+      const result = await this.storageReadTable("app_settings", 1, 1000);
       const setting = result?.data?.find((row: any) => row.key === key);
       return setting?.value || null;
     } catch (error) {
@@ -1766,7 +1906,7 @@ export const api = {
   async saveSetting(key: string, value: string): Promise<void> {
     try {
       // Mirror to localStorage for instant availability on next startup
-      if (typeof window !== 'undefined' && 'localStorage' in window) {
+      if (typeof window !== "undefined" && "localStorage" in window) {
         try {
           window.localStorage.setItem(`app_setting:${key}`, value);
         } catch (_ignore) {
@@ -1775,14 +1915,10 @@ export const api = {
       }
       // Try to update first
       try {
-        await this.storageUpdateRow(
-          'app_settings',
-          { key },
-          { value }
-        );
+        await this.storageUpdateRow("app_settings", { key }, { value });
       } catch (updateError) {
         // If update fails (row doesn't exist), insert new row
-        await this.storageInsertRow('app_settings', { key, value });
+        await this.storageInsertRow("app_settings", { key, value });
       }
     } catch (error) {
       console.error(`Failed to save setting ${key}:`, error);
@@ -1796,9 +1932,15 @@ export const api = {
    * @param projectPath - Project path (required for project and local scopes)
    * @returns Promise resolving to the hooks configuration
    */
-  async getHooksConfig(scope: 'user' | 'project' | 'local', projectPath?: string): Promise<HooksConfiguration> {
+  async getHooksConfig(
+    scope: "user" | "project" | "local",
+    projectPath?: string
+  ): Promise<HooksConfiguration> {
     try {
-      return await apiCall<HooksConfiguration>("get_hooks_config", { scope, projectPath });
+      return await apiCall<HooksConfiguration>("get_hooks_config", {
+        scope,
+        projectPath,
+      });
     } catch (error) {
       console.error("Failed to get hooks config:", error);
       throw error;
@@ -1813,12 +1955,16 @@ export const api = {
    * @returns Promise resolving to success message
    */
   async updateHooksConfig(
-    scope: 'user' | 'project' | 'local',
+    scope: "user" | "project" | "local",
     hooks: HooksConfiguration,
     projectPath?: string
   ): Promise<string> {
     try {
-      return await apiCall<string>("update_hooks_config", { scope, projectPath, hooks });
+      return await apiCall<string>("update_hooks_config", {
+        scope,
+        projectPath,
+        hooks,
+      });
     } catch (error) {
       console.error("Failed to update hooks config:", error);
       throw error;
@@ -1830,9 +1976,14 @@ export const api = {
    * @param command - The shell command to validate
    * @returns Promise resolving to validation result
    */
-  async validateHookCommand(command: string): Promise<{ valid: boolean; message: string }> {
+  async validateHookCommand(
+    command: string
+  ): Promise<{ valid: boolean; message: string }> {
     try {
-      return await apiCall<{ valid: boolean; message: string }>("validate_hook_command", { command });
+      return await apiCall<{ valid: boolean; message: string }>(
+        "validate_hook_command",
+        { command }
+      );
     } catch (error) {
       console.error("Failed to validate hook command:", error);
       throw error;
@@ -1847,13 +1998,13 @@ export const api = {
   async getMergedHooksConfig(projectPath: string): Promise<HooksConfiguration> {
     try {
       const [userHooks, projectHooks, localHooks] = await Promise.all([
-        this.getHooksConfig('user'),
-        this.getHooksConfig('project', projectPath),
-        this.getHooksConfig('local', projectPath)
+        this.getHooksConfig("user"),
+        this.getHooksConfig("project", projectPath),
+        this.getHooksConfig("local", projectPath),
       ]);
 
       // Import HooksManager for merging
-      const { HooksManager } = await import('@/lib/hooksManager');
+      const { HooksManager } = await import("@/lib/hooksManager");
       return HooksManager.mergeConfigs(userHooks, projectHooks, localHooks);
     } catch (error) {
       console.error("Failed to get merged hooks config:", error);
@@ -1870,7 +2021,9 @@ export const api = {
    */
   async slashCommandsList(projectPath?: string): Promise<SlashCommand[]> {
     try {
-      return await apiCall<SlashCommand[]>("slash_commands_list", { projectPath });
+      return await apiCall<SlashCommand[]>("slash_commands_list", {
+        projectPath,
+      });
     } catch (error) {
       console.error("Failed to list slash commands:", error);
       throw error;
@@ -1919,7 +2072,7 @@ export const api = {
         content,
         description,
         allowedTools,
-        projectPath
+        projectPath,
       });
     } catch (error) {
       console.error("Failed to save slash command:", error);
@@ -1933,13 +2086,18 @@ export const api = {
    * @param projectPath - Optional project path for deleting project commands
    * @returns Promise resolving to deletion message
    */
-  async slashCommandDelete(commandId: string, projectPath?: string): Promise<string> {
+  async slashCommandDelete(
+    commandId: string,
+    projectPath?: string
+  ): Promise<string> {
     try {
-      return await apiCall<string>("slash_command_delete", { commandId, projectPath });
+      return await apiCall<string>("slash_command_delete", {
+        commandId,
+        projectPath,
+      });
     } catch (error) {
       console.error("Failed to delete slash command:", error);
       throw error;
     }
   },
-
 };


### PR DESCRIPTION
feat: add multi-environment variable groups support

Implement environment variable groups feature that allows users to
define and switch between different sets of environment variables
for different deployment contexts (dev, staging, production, etc.)

New features:
- EnvGroupSelector component for quick group switching in prompt bar
- Support for creating, editing, and deleting environment groups
- Active group selection persists across sessions
- Backward compatible with existing single env configuration

Changes:
- Add EnvGroupSelector.tsx component
- Add EnvGroup interface to api.ts
- Extend ClaudeSettings with envGroups and activeEnvGroup fields
- Add group management UI in Settings.tsx
- Integrate group selector in FloatingPromptInput.tsx

Also includes:
- Fix chat loading hang by using static imports for Tauri APIs
- Code style cleanup (quote normalization, trailing commas)
<img width="1100" height="651" alt="截屏2025-12-28 20 02 55" src="https://github.com/user-attachments/assets/db51aacd-2605-4c63-be66-9a8dd7efd702" />
<img width="1100" height="651" alt="截屏2025-12-28 20 03 12" src="https://github.com/user-attachments/assets/182a574c-bcf7-4f83-b755-bd676252d8a6" />
<img width="1402" height="803" alt="截屏2025-12-28 20 03 34" src="https://github.com/user-attachments/assets/f84ee9c3-e7d2-40e5-bff7-18b1ddc507c3" />
