### PR TITLE
Fix: resolved LLM response window autoscroll not working

### DIFF
--- a/src/components/SessionOutputViewer.tsx
+++ b/src/components/SessionOutputViewer.tsx
@@ -52,6 +52,7 @@ export function SessionOutputViewer({ session, onClose, className }: SessionOutp
   const fullscreenScrollRef = useRef<HTMLDivElement>(null);
   const fullscreenMessagesEndRef = useRef<HTMLDivElement>(null);
   const unlistenRefs = useRef<UnlistenFn[]>([]);
+  const isProgrammaticScrollRef = useRef(false);
   const { getCachedOutput, setCachedOutput } = useOutputCache();
 
   // Auto-scroll logic similar to AgentExecution
@@ -69,7 +70,12 @@ export function SessionOutputViewer({ session, onClose, className }: SessionOutp
     if (!hasUserScrolled) {
       const endRef = isFullscreen ? fullscreenMessagesEndRef.current : outputEndRef.current;
       if (endRef) {
+        isProgrammaticScrollRef.current = true;
         endRef.scrollIntoView({ behavior: 'smooth' });
+        // Reset flag after scroll completes
+        setTimeout(() => {
+          isProgrammaticScrollRef.current = false;
+        }, 0);
       }
     }
   };
@@ -476,15 +482,18 @@ export function SessionOutputViewer({ session, onClose, className }: SessionOutp
                 </div>
               </div>
             ) : (
-              <div 
-                className="h-full overflow-y-auto p-6 space-y-3" 
+              <div
+                className="h-full overflow-y-auto p-6 space-y-3"
                 ref={scrollAreaRef}
                 onScroll={() => {
+                  // Skip if this is a programmatic scroll from scrollIntoView
+                  if (isProgrammaticScrollRef.current) return;
+
                   // Mark that user has scrolled manually
                   if (!hasUserScrolled) {
                     setHasUserScrolled(true);
                   }
-                  
+
                   // If user scrolls back to bottom, re-enable auto-scroll
                   if (isAtBottom()) {
                     setHasUserScrolled(false);
@@ -610,15 +619,18 @@ export function SessionOutputViewer({ session, onClose, className }: SessionOutp
 
           {/* Modal Content */}
           <div className="flex-1 overflow-hidden p-6">
-            <div 
+            <div
               ref={fullscreenScrollRef}
               className="h-full overflow-y-auto space-y-3"
               onScroll={() => {
+                // Skip if this is a programmatic scroll from scrollIntoView
+                if (isProgrammaticScrollRef.current) return;
+
                 // Mark that user has scrolled manually
                 if (!hasUserScrolled) {
                   setHasUserScrolled(true);
                 }
-                
+
                 // If user scrolls back to bottom, re-enable auto-scroll
                 if (isAtBottom()) {
                   setHasUserScrolled(false);


### PR DESCRIPTION
## Summary
Fixed the auto-scroll issue in `SessionOutputViewer` where the window was not scrolling down as new LLM responses arrived.

## Problem
The auto-scroll functionality was broken because the `onScroll` event handler was treating programmatic scrolls (from `scrollIntoView()`) the same as user-initiated scrolls. This caused the `hasUserScrolled` flag to be incorrectly set, preventing automatic scrolling to new messages when they arrived.

## Solution
Added a `isProgrammaticScrollRef` flag to distinguish between:
- **Programmatic scrolls**: Triggered by `scrollIntoView()` (should not affect auto-scroll state)
- **User scrolls**: Manual scrolling by the user (should control auto-scroll behavior)

The fix:
1. Sets `isProgrammaticScrollRef.current = true` before calling `scrollIntoView()`
2. Resets the flag immediately after via `setTimeout(..., 0)`
3. The `onScroll` handler checks this flag and skips state updates for programmatic scrolls

## Changes Made
- `src/components/SessionOutputViewer.tsx`:
  - Added `isProgrammaticScrollRef` useRef hook
  - Modified `scrollToBottom()` to set the flag during programmatic scrolls
  - Updated both scroll area `onScroll` handlers (normal and fullscreen) to skip processing when flag is set

## Testing
Verified in both normal and fullscreen modes:
- Auto-scroll now correctly engages when new messages arrive
- User manual scrolls up properly stop auto-scroll
- Scrolling back to bottom re-enables auto-scroll
- No visual glitches or infinite scroll loops